### PR TITLE
Feat serialize attachments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,6 +137,9 @@ venv.bak/
 .spyderproject
 .spyproject
 
+# VS Code settings
+.vscode/
+
 # Rope project settings
 .ropeproject
 


### PR DESCRIPTION
Work item attachments take content as bytes.
When calculating the workitem checksum a JSON dump is performed but bytes aren't JSON serialisable.
Regarding checksum, when checksum of attachments differ doesn't mean the whole work item needs to be patched and if work item checksum differs doesn't necessarily mean attachments need patching either.