### PR TITLE
chore: Rename organisation name in license header and license files

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,4 +1,4 @@
-Copyright DB Netz AG and contributors
+Copyright DB InfraGO AG and contributors
 SPDX-License-Identifier: CC0-1.0
 
 node: $Format:%H$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: CC0-1.0
 
 * text=auto

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: CC0-1.0
 
 name: Build

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: CC0-1.0
 
 name: Docs

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: CC0-1.0
 
 name: Lint

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: CC0-1.0
 
 # Byte-compiled / optimized / DLL files

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 stages:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: CC0-1.0
 
 default_install_hook_types: [commit-msg, pre-commit]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 <!--
- ~ Copyright DB Netz AG and contributors
+ ~ Copyright DB InfraGO AG and contributors
  ~ SPDX-License-Identifier: Apache-2.0
  -->
 

--- a/LICENSES/.license_header.txt
+++ b/LICENSES/.license_header.txt
@@ -1,2 +1,2 @@
-Copyright DB Netz AG and contributors
+Copyright DB InfraGO AG and contributors
 SPDX-License-Identifier: Apache-2.0

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
- ~ Copyright DB Netz AG and contributors
+ ~ Copyright DB InfraGO AG and contributors
  ~ SPDX-License-Identifier: Apache-2.0
  -->
 
@@ -133,7 +133,7 @@ look at our [guidelines for contributors](CONTRIBUTING.md) for details.
 This project is compliant with the
 [REUSE Specification Version 3.0](https://git.fsfe.org/reuse/docs/src/commit/d173a27231a36e1a2a3af07421f5e557ae0fec46/spec.md).
 
-Copyright DB Netz AG, licensed under Apache 2.0 (see full text in
+Copyright DB InfraGO AG, licensed under Apache 2.0 (see full text in
 [LICENSES/Apache-2.0.txt](LICENSES/Apache-2.0.txt))
 
 Dot-files are licensed under CC0-1.0 (see full text in

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: CC0-1.0
 
 # Minimal makefile for Sphinx documentation

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,5 +1,5 @@
 @ECHO OFF
-REM Copyright DB Netz AG and contributors
+REM Copyright DB InfraGO AG and contributors
 REM SPDX-License-Identifier: CC0-1.0
 
 pushd %~dp0

--- a/docs/source/_static/github-logo.svg
+++ b/docs/source/_static/github-logo.svg
@@ -1,5 +1,5 @@
 <!--
- ~ SPDX-FileCopyrightText: Copyright DB Netz AG and the capellambse contributors
+ ~ SPDX-FileCopyrightText: Copyright DB InfraGO AG and the capellambse contributors
  ~ SPDX-License-Identifier: Apache-2.0
  -->
 <svg stroke="currentColor" fill="currentColor" stroke-width="0" viewBox="0 0 16 16">

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 """Configuration file for Sphinx."""
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,5 +1,5 @@
 ..
-   Copyright DB Netz AG and contributors
+   Copyright DB InfraGO AG and contributors
    SPDX-License-Identifier: Apache-2.0
 
 Welcome to polarion-rest-api-client's documentation!

--- a/git-conventional-commits.json.license
+++ b/git-conventional-commits.json.license
@@ -1,2 +1,2 @@
-Copyright DB Netz AG and contributors
+Copyright DB InfraGO AG and contributors
 SPDX-License-Identifier: CC0-1.0

--- a/open_api_client_build/build_client_source.sh
+++ b/open_api_client_build/build_client_source.sh
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 #/bin/bash

--- a/open_api_client_build/config.yaml
+++ b/open_api_client_build/config.yaml
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 package_name_override: open_api_client

--- a/open_api_client_build/custom_templates/client.py.jinja.license
+++ b/open_api_client_build/custom_templates/client.py.jinja.license
@@ -1,2 +1,2 @@
-Copyright https://github.com/openapi-generators/openapi-python-client, DB Netz AG and contributors
+Copyright https://github.com/openapi-generators/openapi-python-client, DB InfraGO AG and contributors
 SPDX-License-Identifier: Apache-2.0

--- a/open_api_client_build/custom_templates/endpoint_macros.py.jinja.license
+++ b/open_api_client_build/custom_templates/endpoint_macros.py.jinja.license
@@ -1,2 +1,2 @@
-Copyright https://github.com/openapi-generators/openapi-python-client, DB Netz AG and contributors
+Copyright https://github.com/openapi-generators/openapi-python-client, DB InfraGO AG and contributors
 SPDX-License-Identifier: Apache-2.0

--- a/open_api_client_build/custom_templates/model.py.jinja.license
+++ b/open_api_client_build/custom_templates/model.py.jinja.license
@@ -1,2 +1,2 @@
-Copyright https://github.com/openapi-generators/openapi-python-client, DB Netz AG and contributors
+Copyright https://github.com/openapi-generators/openapi-python-client, DB InfraGO AG and contributors
 SPDX-License-Identifier: Apache-2.0

--- a/open_api_client_build/custom_templates/property_templates/model_property.py.jinja.license
+++ b/open_api_client_build/custom_templates/property_templates/model_property.py.jinja.license
@@ -1,2 +1,2 @@
-Copyright https://github.com/openapi-generators/openapi-python-client, DB Netz AG and contributors
+Copyright https://github.com/openapi-generators/openapi-python-client, DB InfraGO AG and contributors
 SPDX-License-Identifier: Apache-2.0

--- a/polarion_rest_api_client/__init__.py
+++ b/polarion_rest_api_client/__init__.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 """Polarion API module serving all data classes, clients and errors."""
 from importlib import metadata

--- a/polarion_rest_api_client/base_client.py
+++ b/polarion_rest_api_client/base_client.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 """Base class for a polarion project client to easily rewrite the client."""
 from __future__ import annotations

--- a/polarion_rest_api_client/client.py
+++ b/polarion_rest_api_client/client.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 """The actual implementation of the API client using an OpenAPIClient."""
 from __future__ import annotations

--- a/polarion_rest_api_client/data_models.py
+++ b/polarion_rest_api_client/data_models.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 """Data model classes returned by the client."""
 from __future__ import annotations

--- a/polarion_rest_api_client/errors.py
+++ b/polarion_rest_api_client/errors.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 """Polarion API related errors."""
 from __future__ import annotations

--- a/polarion_rest_api_client/open_api_client/__init__.py
+++ b/polarion_rest_api_client/open_api_client/__init__.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 """A client library for accessing Polarion REST API."""
 from .client import AuthenticatedClient, Client

--- a/polarion_rest_api_client/open_api_client/api/__init__.py
+++ b/polarion_rest_api_client/open_api_client/api/__init__.py
@@ -1,3 +1,3 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 """Contains methods for accessing the API."""

--- a/polarion_rest_api_client/open_api_client/api/document_attachments/__init__.py
+++ b/polarion_rest_api_client/open_api_client/api/document_attachments/__init__.py
@@ -1,2 +1,2 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0

--- a/polarion_rest_api_client/open_api_client/api/document_attachments/get_document_attachment.py
+++ b/polarion_rest_api_client/open_api_client/api/document_attachments/get_document_attachment.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/document_attachments/get_document_attachment_content.py
+++ b/polarion_rest_api_client/open_api_client/api/document_attachments/get_document_attachment_content.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/document_attachments/get_document_attachments.py
+++ b/polarion_rest_api_client/open_api_client/api/document_attachments/get_document_attachments.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/document_attachments/patch_document_attachment.py
+++ b/polarion_rest_api_client/open_api_client/api/document_attachments/patch_document_attachment.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/document_attachments/post_document_item_attachments.py
+++ b/polarion_rest_api_client/open_api_client/api/document_attachments/post_document_item_attachments.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/document_comments/__init__.py
+++ b/polarion_rest_api_client/open_api_client/api/document_comments/__init__.py
@@ -1,2 +1,2 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0

--- a/polarion_rest_api_client/open_api_client/api/document_comments/get_document_comment.py
+++ b/polarion_rest_api_client/open_api_client/api/document_comments/get_document_comment.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/document_comments/get_document_comments.py
+++ b/polarion_rest_api_client/open_api_client/api/document_comments/get_document_comments.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/document_comments/patch_document_comment.py
+++ b/polarion_rest_api_client/open_api_client/api/document_comments/patch_document_comment.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/document_comments/post_document_comments.py
+++ b/polarion_rest_api_client/open_api_client/api/document_comments/post_document_comments.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/document_parts/__init__.py
+++ b/polarion_rest_api_client/open_api_client/api/document_parts/__init__.py
@@ -1,2 +1,2 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0

--- a/polarion_rest_api_client/open_api_client/api/document_parts/get_document_part.py
+++ b/polarion_rest_api_client/open_api_client/api/document_parts/get_document_part.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/document_parts/get_document_parts.py
+++ b/polarion_rest_api_client/open_api_client/api/document_parts/get_document_parts.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/document_parts/post_document_parts.py
+++ b/polarion_rest_api_client/open_api_client/api/document_parts/post_document_parts.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/documents/__init__.py
+++ b/polarion_rest_api_client/open_api_client/api/documents/__init__.py
@@ -1,2 +1,2 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0

--- a/polarion_rest_api_client/open_api_client/api/documents/branch_document.py
+++ b/polarion_rest_api_client/open_api_client/api/documents/branch_document.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/documents/copy_document.py
+++ b/polarion_rest_api_client/open_api_client/api/documents/copy_document.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/documents/get_available_enum_options_for_document.py
+++ b/polarion_rest_api_client/open_api_client/api/documents/get_available_enum_options_for_document.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/documents/get_available_enum_options_for_document_type.py
+++ b/polarion_rest_api_client/open_api_client/api/documents/get_available_enum_options_for_document_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/documents/get_current_enumeration_options_for_document.py
+++ b/polarion_rest_api_client/open_api_client/api/documents/get_current_enumeration_options_for_document.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/documents/get_document.py
+++ b/polarion_rest_api_client/open_api_client/api/documents/get_document.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/documents/patch_document.py
+++ b/polarion_rest_api_client/open_api_client/api/documents/patch_document.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/documents/post_documents.py
+++ b/polarion_rest_api_client/open_api_client/api/documents/post_documents.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/enumerations/__init__.py
+++ b/polarion_rest_api_client/open_api_client/api/enumerations/__init__.py
@@ -1,2 +1,2 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0

--- a/polarion_rest_api_client/open_api_client/api/enumerations/delete_global_enumeration.py
+++ b/polarion_rest_api_client/open_api_client/api/enumerations/delete_global_enumeration.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/enumerations/delete_project_enumeration.py
+++ b/polarion_rest_api_client/open_api_client/api/enumerations/delete_project_enumeration.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/enumerations/get_global_enumeration.py
+++ b/polarion_rest_api_client/open_api_client/api/enumerations/get_global_enumeration.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/enumerations/get_project_enumeration.py
+++ b/polarion_rest_api_client/open_api_client/api/enumerations/get_project_enumeration.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/enumerations/patch_global_enumeration.py
+++ b/polarion_rest_api_client/open_api_client/api/enumerations/patch_global_enumeration.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/enumerations/patch_project_enumeration.py
+++ b/polarion_rest_api_client/open_api_client/api/enumerations/patch_project_enumeration.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/enumerations/post_global_enumeration.py
+++ b/polarion_rest_api_client/open_api_client/api/enumerations/post_global_enumeration.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/enumerations/post_project_enumeration.py
+++ b/polarion_rest_api_client/open_api_client/api/enumerations/post_project_enumeration.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/icons/__init__.py
+++ b/polarion_rest_api_client/open_api_client/api/icons/__init__.py
@@ -1,2 +1,2 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0

--- a/polarion_rest_api_client/open_api_client/api/icons/get_default_icon.py
+++ b/polarion_rest_api_client/open_api_client/api/icons/get_default_icon.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/icons/get_default_icons.py
+++ b/polarion_rest_api_client/open_api_client/api/icons/get_default_icons.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/icons/get_global_icon.py
+++ b/polarion_rest_api_client/open_api_client/api/icons/get_global_icon.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/icons/get_global_icons.py
+++ b/polarion_rest_api_client/open_api_client/api/icons/get_global_icons.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/icons/get_project_icon.py
+++ b/polarion_rest_api_client/open_api_client/api/icons/get_project_icon.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/icons/get_project_icons.py
+++ b/polarion_rest_api_client/open_api_client/api/icons/get_project_icons.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/linked_work_items/__init__.py
+++ b/polarion_rest_api_client/open_api_client/api/linked_work_items/__init__.py
@@ -1,2 +1,2 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0

--- a/polarion_rest_api_client/open_api_client/api/linked_work_items/delete_linked_work_item.py
+++ b/polarion_rest_api_client/open_api_client/api/linked_work_items/delete_linked_work_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/linked_work_items/delete_linked_work_items.py
+++ b/polarion_rest_api_client/open_api_client/api/linked_work_items/delete_linked_work_items.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/linked_work_items/get_linked_work_item.py
+++ b/polarion_rest_api_client/open_api_client/api/linked_work_items/get_linked_work_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/linked_work_items/get_linked_work_items.py
+++ b/polarion_rest_api_client/open_api_client/api/linked_work_items/get_linked_work_items.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/linked_work_items/patch_linked_work_item.py
+++ b/polarion_rest_api_client/open_api_client/api/linked_work_items/patch_linked_work_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/linked_work_items/post_linked_work_items.py
+++ b/polarion_rest_api_client/open_api_client/api/linked_work_items/post_linked_work_items.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/page_attachments/__init__.py
+++ b/polarion_rest_api_client/open_api_client/api/page_attachments/__init__.py
@@ -1,2 +1,2 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0

--- a/polarion_rest_api_client/open_api_client/api/page_attachments/get_page_attachment.py
+++ b/polarion_rest_api_client/open_api_client/api/page_attachments/get_page_attachment.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/page_attachments/get_page_attachment_content.py
+++ b/polarion_rest_api_client/open_api_client/api/page_attachments/get_page_attachment_content.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/page_attachments/post_page_attachments.py
+++ b/polarion_rest_api_client/open_api_client/api/page_attachments/post_page_attachments.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/pages/__init__.py
+++ b/polarion_rest_api_client/open_api_client/api/pages/__init__.py
@@ -1,2 +1,2 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0

--- a/polarion_rest_api_client/open_api_client/api/pages/get_page.py
+++ b/polarion_rest_api_client/open_api_client/api/pages/get_page.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/pages/patch_rich_page.py
+++ b/polarion_rest_api_client/open_api_client/api/pages/patch_rich_page.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/projects/__init__.py
+++ b/polarion_rest_api_client/open_api_client/api/projects/__init__.py
@@ -1,2 +1,2 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0

--- a/polarion_rest_api_client/open_api_client/api/projects/get_project.py
+++ b/polarion_rest_api_client/open_api_client/api/projects/get_project.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/projects/get_projects.py
+++ b/polarion_rest_api_client/open_api_client/api/projects/get_projects.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/roles/__init__.py
+++ b/polarion_rest_api_client/open_api_client/api/roles/__init__.py
@@ -1,2 +1,2 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0

--- a/polarion_rest_api_client/open_api_client/api/roles/get_role.py
+++ b/polarion_rest_api_client/open_api_client/api/roles/get_role.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/user_groups/__init__.py
+++ b/polarion_rest_api_client/open_api_client/api/user_groups/__init__.py
@@ -1,2 +1,2 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0

--- a/polarion_rest_api_client/open_api_client/api/user_groups/get_user_group.py
+++ b/polarion_rest_api_client/open_api_client/api/user_groups/get_user_group.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/users/__init__.py
+++ b/polarion_rest_api_client/open_api_client/api/users/__init__.py
@@ -1,2 +1,2 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0

--- a/polarion_rest_api_client/open_api_client/api/users/get_user.py
+++ b/polarion_rest_api_client/open_api_client/api/users/get_user.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/users/get_users.py
+++ b/polarion_rest_api_client/open_api_client/api/users/get_users.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/users/patch_user.py
+++ b/polarion_rest_api_client/open_api_client/api/users/patch_user.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/users/post_users.py
+++ b/polarion_rest_api_client/open_api_client/api/users/post_users.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/users/set_license.py
+++ b/polarion_rest_api_client/open_api_client/api/users/set_license.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/work_item_attachments/__init__.py
+++ b/polarion_rest_api_client/open_api_client/api/work_item_attachments/__init__.py
@@ -1,2 +1,2 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0

--- a/polarion_rest_api_client/open_api_client/api/work_item_attachments/delete_work_item_attachment.py
+++ b/polarion_rest_api_client/open_api_client/api/work_item_attachments/delete_work_item_attachment.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/work_item_attachments/get_work_item_attachment.py
+++ b/polarion_rest_api_client/open_api_client/api/work_item_attachments/get_work_item_attachment.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/work_item_attachments/get_work_item_attachment_content.py
+++ b/polarion_rest_api_client/open_api_client/api/work_item_attachments/get_work_item_attachment_content.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/work_item_attachments/get_work_item_attachments.py
+++ b/polarion_rest_api_client/open_api_client/api/work_item_attachments/get_work_item_attachments.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/work_item_attachments/patch_work_item_attachment.py
+++ b/polarion_rest_api_client/open_api_client/api/work_item_attachments/patch_work_item_attachment.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/work_item_attachments/post_work_item_attachments.py
+++ b/polarion_rest_api_client/open_api_client/api/work_item_attachments/post_work_item_attachments.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/work_item_comments/__init__.py
+++ b/polarion_rest_api_client/open_api_client/api/work_item_comments/__init__.py
@@ -1,2 +1,2 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0

--- a/polarion_rest_api_client/open_api_client/api/work_item_comments/get_comment.py
+++ b/polarion_rest_api_client/open_api_client/api/work_item_comments/get_comment.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/work_item_comments/get_comments.py
+++ b/polarion_rest_api_client/open_api_client/api/work_item_comments/get_comments.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/work_item_comments/patch_comment.py
+++ b/polarion_rest_api_client/open_api_client/api/work_item_comments/patch_comment.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/work_item_comments/post_comments.py
+++ b/polarion_rest_api_client/open_api_client/api/work_item_comments/post_comments.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/work_items/__init__.py
+++ b/polarion_rest_api_client/open_api_client/api/work_items/__init__.py
@@ -1,2 +1,2 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0

--- a/polarion_rest_api_client/open_api_client/api/work_items/delete_work_items.py
+++ b/polarion_rest_api_client/open_api_client/api/work_items/delete_work_items.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/work_items/get_all_work_items.py
+++ b/polarion_rest_api_client/open_api_client/api/work_items/get_all_work_items.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/work_items/get_available_enum_options_for_work_item.py
+++ b/polarion_rest_api_client/open_api_client/api/work_items/get_available_enum_options_for_work_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/work_items/get_available_enum_options_for_work_item_type.py
+++ b/polarion_rest_api_client/open_api_client/api/work_items/get_available_enum_options_for_work_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/work_items/get_current_enum_options_for_work_item.py
+++ b/polarion_rest_api_client/open_api_client/api/work_items/get_current_enum_options_for_work_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/work_items/get_work_item.py
+++ b/polarion_rest_api_client/open_api_client/api/work_items/get_work_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/work_items/get_work_items.py
+++ b/polarion_rest_api_client/open_api_client/api/work_items/get_work_items.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/work_items/move_from_document.py
+++ b/polarion_rest_api_client/open_api_client/api/work_items/move_from_document.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/work_items/move_to_document.py
+++ b/polarion_rest_api_client/open_api_client/api/work_items/move_to_document.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/work_items/patch_work_item.py
+++ b/polarion_rest_api_client/open_api_client/api/work_items/patch_work_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/api/work_items/post_work_items.py
+++ b/polarion_rest_api_client/open_api_client/api/work_items/post_work_items.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from http import HTTPStatus

--- a/polarion_rest_api_client/open_api_client/client.py
+++ b/polarion_rest_api_client/open_api_client/client.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 import ssl

--- a/polarion_rest_api_client/open_api_client/errors.py
+++ b/polarion_rest_api_client/open_api_client/errors.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 """Contains shared errors types that can be raised from API functions."""
 

--- a/polarion_rest_api_client/open_api_client/models/__init__.py
+++ b/polarion_rest_api_client/open_api_client/models/__init__.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 """Contains all the data models used in inputs/outputs."""
 

--- a/polarion_rest_api_client/open_api_client/models/branch_document_request_body.py
+++ b/polarion_rest_api_client/open_api_client/models/branch_document_request_body.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/copy_document_request_body.py
+++ b/polarion_rest_api_client/open_api_client/models/copy_document_request_body.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_attachments_list_get_response.py
+++ b/polarion_rest_api_client/open_api_client/models/document_attachments_list_get_response.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_attachments_list_get_response_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/document_attachments_list_get_response_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_attachments_list_get_response_data_item_attributes.py
+++ b/polarion_rest_api_client/open_api_client/models/document_attachments_list_get_response_data_item_attributes.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 import datetime

--- a/polarion_rest_api_client/open_api_client/models/document_attachments_list_get_response_data_item_links.py
+++ b/polarion_rest_api_client/open_api_client/models/document_attachments_list_get_response_data_item_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_attachments_list_get_response_data_item_meta.py
+++ b/polarion_rest_api_client/open_api_client/models/document_attachments_list_get_response_data_item_meta.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_attachments_list_get_response_data_item_meta_errors_item.py
+++ b/polarion_rest_api_client/open_api_client/models/document_attachments_list_get_response_data_item_meta_errors_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_attachments_list_get_response_data_item_meta_errors_item_source.py
+++ b/polarion_rest_api_client/open_api_client/models/document_attachments_list_get_response_data_item_meta_errors_item_source.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_attachments_list_get_response_data_item_relationships.py
+++ b/polarion_rest_api_client/open_api_client/models/document_attachments_list_get_response_data_item_relationships.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_attachments_list_get_response_data_item_relationships_author.py
+++ b/polarion_rest_api_client/open_api_client/models/document_attachments_list_get_response_data_item_relationships_author.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_attachments_list_get_response_data_item_relationships_author_data.py
+++ b/polarion_rest_api_client/open_api_client/models/document_attachments_list_get_response_data_item_relationships_author_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_attachments_list_get_response_data_item_relationships_author_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/document_attachments_list_get_response_data_item_relationships_author_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/document_attachments_list_get_response_data_item_relationships_project.py
+++ b/polarion_rest_api_client/open_api_client/models/document_attachments_list_get_response_data_item_relationships_project.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_attachments_list_get_response_data_item_relationships_project_data.py
+++ b/polarion_rest_api_client/open_api_client/models/document_attachments_list_get_response_data_item_relationships_project_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_attachments_list_get_response_data_item_relationships_project_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/document_attachments_list_get_response_data_item_relationships_project_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/document_attachments_list_get_response_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/document_attachments_list_get_response_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/document_attachments_list_get_response_included_item.py
+++ b/polarion_rest_api_client/open_api_client/models/document_attachments_list_get_response_included_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar

--- a/polarion_rest_api_client/open_api_client/models/document_attachments_list_get_response_links.py
+++ b/polarion_rest_api_client/open_api_client/models/document_attachments_list_get_response_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_attachments_list_get_response_meta.py
+++ b/polarion_rest_api_client/open_api_client/models/document_attachments_list_get_response_meta.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_attachments_list_post_request.py
+++ b/polarion_rest_api_client/open_api_client/models/document_attachments_list_post_request.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_attachments_list_post_request_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/document_attachments_list_post_request_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_attachments_list_post_request_data_item_attributes.py
+++ b/polarion_rest_api_client/open_api_client/models/document_attachments_list_post_request_data_item_attributes.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_attachments_list_post_request_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/document_attachments_list_post_request_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/document_attachments_list_post_response.py
+++ b/polarion_rest_api_client/open_api_client/models/document_attachments_list_post_response.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_attachments_list_post_response_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/document_attachments_list_post_response_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_attachments_list_post_response_data_item_links.py
+++ b/polarion_rest_api_client/open_api_client/models/document_attachments_list_post_response_data_item_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_attachments_list_post_response_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/document_attachments_list_post_response_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/document_attachments_single_get_response.py
+++ b/polarion_rest_api_client/open_api_client/models/document_attachments_single_get_response.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_attachments_single_get_response_data.py
+++ b/polarion_rest_api_client/open_api_client/models/document_attachments_single_get_response_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_attachments_single_get_response_data_attributes.py
+++ b/polarion_rest_api_client/open_api_client/models/document_attachments_single_get_response_data_attributes.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 import datetime

--- a/polarion_rest_api_client/open_api_client/models/document_attachments_single_get_response_data_links.py
+++ b/polarion_rest_api_client/open_api_client/models/document_attachments_single_get_response_data_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_attachments_single_get_response_data_meta.py
+++ b/polarion_rest_api_client/open_api_client/models/document_attachments_single_get_response_data_meta.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_attachments_single_get_response_data_meta_errors_item.py
+++ b/polarion_rest_api_client/open_api_client/models/document_attachments_single_get_response_data_meta_errors_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_attachments_single_get_response_data_meta_errors_item_source.py
+++ b/polarion_rest_api_client/open_api_client/models/document_attachments_single_get_response_data_meta_errors_item_source.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_attachments_single_get_response_data_relationships.py
+++ b/polarion_rest_api_client/open_api_client/models/document_attachments_single_get_response_data_relationships.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_attachments_single_get_response_data_relationships_author.py
+++ b/polarion_rest_api_client/open_api_client/models/document_attachments_single_get_response_data_relationships_author.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_attachments_single_get_response_data_relationships_author_data.py
+++ b/polarion_rest_api_client/open_api_client/models/document_attachments_single_get_response_data_relationships_author_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_attachments_single_get_response_data_relationships_author_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/document_attachments_single_get_response_data_relationships_author_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/document_attachments_single_get_response_data_relationships_project.py
+++ b/polarion_rest_api_client/open_api_client/models/document_attachments_single_get_response_data_relationships_project.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_attachments_single_get_response_data_relationships_project_data.py
+++ b/polarion_rest_api_client/open_api_client/models/document_attachments_single_get_response_data_relationships_project_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_attachments_single_get_response_data_relationships_project_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/document_attachments_single_get_response_data_relationships_project_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/document_attachments_single_get_response_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/document_attachments_single_get_response_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/document_attachments_single_get_response_included_item.py
+++ b/polarion_rest_api_client/open_api_client/models/document_attachments_single_get_response_included_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar

--- a/polarion_rest_api_client/open_api_client/models/document_attachments_single_get_response_links.py
+++ b/polarion_rest_api_client/open_api_client/models/document_attachments_single_get_response_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_attachments_single_patch_request.py
+++ b/polarion_rest_api_client/open_api_client/models/document_attachments_single_patch_request.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_attachments_single_patch_request_data.py
+++ b/polarion_rest_api_client/open_api_client/models/document_attachments_single_patch_request_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_attachments_single_patch_request_data_attributes.py
+++ b/polarion_rest_api_client/open_api_client/models/document_attachments_single_patch_request_data_attributes.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_attachments_single_patch_request_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/document_attachments_single_patch_request_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/document_comments_list_get_response.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_list_get_response.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_comments_list_get_response_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_list_get_response_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_comments_list_get_response_data_item_attributes.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_list_get_response_data_item_attributes.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 import datetime

--- a/polarion_rest_api_client/open_api_client/models/document_comments_list_get_response_data_item_attributes_text.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_list_get_response_data_item_attributes_text.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_comments_list_get_response_data_item_attributes_text_type.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_list_get_response_data_item_attributes_text_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/document_comments_list_get_response_data_item_links.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_list_get_response_data_item_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_comments_list_get_response_data_item_meta.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_list_get_response_data_item_meta.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_comments_list_get_response_data_item_meta_errors_item.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_list_get_response_data_item_meta_errors_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_comments_list_get_response_data_item_meta_errors_item_source.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_list_get_response_data_item_meta_errors_item_source.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_comments_list_get_response_data_item_relationships.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_list_get_response_data_item_relationships.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_comments_list_get_response_data_item_relationships_author.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_list_get_response_data_item_relationships_author.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_comments_list_get_response_data_item_relationships_author_data.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_list_get_response_data_item_relationships_author_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_comments_list_get_response_data_item_relationships_author_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_list_get_response_data_item_relationships_author_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/document_comments_list_get_response_data_item_relationships_child_comments.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_list_get_response_data_item_relationships_child_comments.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_comments_list_get_response_data_item_relationships_child_comments_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_list_get_response_data_item_relationships_child_comments_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_comments_list_get_response_data_item_relationships_child_comments_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_list_get_response_data_item_relationships_child_comments_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/document_comments_list_get_response_data_item_relationships_child_comments_meta.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_list_get_response_data_item_relationships_child_comments_meta.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_comments_list_get_response_data_item_relationships_parent_comment.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_list_get_response_data_item_relationships_parent_comment.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_comments_list_get_response_data_item_relationships_parent_comment_data.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_list_get_response_data_item_relationships_parent_comment_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_comments_list_get_response_data_item_relationships_parent_comment_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_list_get_response_data_item_relationships_parent_comment_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/document_comments_list_get_response_data_item_relationships_project.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_list_get_response_data_item_relationships_project.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_comments_list_get_response_data_item_relationships_project_data.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_list_get_response_data_item_relationships_project_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_comments_list_get_response_data_item_relationships_project_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_list_get_response_data_item_relationships_project_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/document_comments_list_get_response_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_list_get_response_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/document_comments_list_get_response_included_item.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_list_get_response_included_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar

--- a/polarion_rest_api_client/open_api_client/models/document_comments_list_get_response_links.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_list_get_response_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_comments_list_get_response_meta.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_list_get_response_meta.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_comments_list_post_request.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_list_post_request.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_comments_list_post_request_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_list_post_request_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_comments_list_post_request_data_item_attributes.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_list_post_request_data_item_attributes.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_comments_list_post_request_data_item_attributes_text.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_list_post_request_data_item_attributes_text.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_comments_list_post_request_data_item_attributes_text_type.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_list_post_request_data_item_attributes_text_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/document_comments_list_post_request_data_item_relationships.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_list_post_request_data_item_relationships.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_comments_list_post_request_data_item_relationships_author.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_list_post_request_data_item_relationships_author.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_comments_list_post_request_data_item_relationships_author_data.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_list_post_request_data_item_relationships_author_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_comments_list_post_request_data_item_relationships_author_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_list_post_request_data_item_relationships_author_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/document_comments_list_post_request_data_item_relationships_parent_comment.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_list_post_request_data_item_relationships_parent_comment.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_comments_list_post_request_data_item_relationships_parent_comment_data.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_list_post_request_data_item_relationships_parent_comment_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_comments_list_post_request_data_item_relationships_parent_comment_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_list_post_request_data_item_relationships_parent_comment_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/document_comments_list_post_request_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_list_post_request_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/document_comments_list_post_response.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_list_post_response.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_comments_list_post_response_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_list_post_response_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_comments_list_post_response_data_item_links.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_list_post_response_data_item_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_comments_list_post_response_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_list_post_response_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/document_comments_single_get_response.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_single_get_response.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_comments_single_get_response_data.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_single_get_response_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_comments_single_get_response_data_attributes.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_single_get_response_data_attributes.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 import datetime

--- a/polarion_rest_api_client/open_api_client/models/document_comments_single_get_response_data_attributes_text.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_single_get_response_data_attributes_text.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_comments_single_get_response_data_attributes_text_type.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_single_get_response_data_attributes_text_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/document_comments_single_get_response_data_links.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_single_get_response_data_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_comments_single_get_response_data_meta.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_single_get_response_data_meta.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_comments_single_get_response_data_meta_errors_item.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_single_get_response_data_meta_errors_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_comments_single_get_response_data_meta_errors_item_source.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_single_get_response_data_meta_errors_item_source.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_comments_single_get_response_data_relationships.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_single_get_response_data_relationships.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_comments_single_get_response_data_relationships_author.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_single_get_response_data_relationships_author.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_comments_single_get_response_data_relationships_author_data.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_single_get_response_data_relationships_author_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_comments_single_get_response_data_relationships_author_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_single_get_response_data_relationships_author_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/document_comments_single_get_response_data_relationships_child_comments.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_single_get_response_data_relationships_child_comments.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_comments_single_get_response_data_relationships_child_comments_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_single_get_response_data_relationships_child_comments_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_comments_single_get_response_data_relationships_child_comments_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_single_get_response_data_relationships_child_comments_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/document_comments_single_get_response_data_relationships_child_comments_meta.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_single_get_response_data_relationships_child_comments_meta.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_comments_single_get_response_data_relationships_parent_comment.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_single_get_response_data_relationships_parent_comment.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_comments_single_get_response_data_relationships_parent_comment_data.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_single_get_response_data_relationships_parent_comment_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_comments_single_get_response_data_relationships_parent_comment_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_single_get_response_data_relationships_parent_comment_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/document_comments_single_get_response_data_relationships_project.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_single_get_response_data_relationships_project.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_comments_single_get_response_data_relationships_project_data.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_single_get_response_data_relationships_project_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_comments_single_get_response_data_relationships_project_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_single_get_response_data_relationships_project_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/document_comments_single_get_response_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_single_get_response_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/document_comments_single_get_response_included_item.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_single_get_response_included_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar

--- a/polarion_rest_api_client/open_api_client/models/document_comments_single_get_response_links.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_single_get_response_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_comments_single_patch_request.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_single_patch_request.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_comments_single_patch_request_data.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_single_patch_request_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_comments_single_patch_request_data_attributes.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_single_patch_request_data_attributes.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_comments_single_patch_request_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/document_comments_single_patch_request_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/document_parts_list_get_response.py
+++ b/polarion_rest_api_client/open_api_client/models/document_parts_list_get_response.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_parts_list_get_response_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/document_parts_list_get_response_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_parts_list_get_response_data_item_attributes.py
+++ b/polarion_rest_api_client/open_api_client/models/document_parts_list_get_response_data_item_attributes.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_parts_list_get_response_data_item_links.py
+++ b/polarion_rest_api_client/open_api_client/models/document_parts_list_get_response_data_item_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_parts_list_get_response_data_item_meta.py
+++ b/polarion_rest_api_client/open_api_client/models/document_parts_list_get_response_data_item_meta.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_parts_list_get_response_data_item_meta_errors_item.py
+++ b/polarion_rest_api_client/open_api_client/models/document_parts_list_get_response_data_item_meta_errors_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_parts_list_get_response_data_item_meta_errors_item_source.py
+++ b/polarion_rest_api_client/open_api_client/models/document_parts_list_get_response_data_item_meta_errors_item_source.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_parts_list_get_response_data_item_relationships.py
+++ b/polarion_rest_api_client/open_api_client/models/document_parts_list_get_response_data_item_relationships.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_parts_list_get_response_data_item_relationships_next_part.py
+++ b/polarion_rest_api_client/open_api_client/models/document_parts_list_get_response_data_item_relationships_next_part.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_parts_list_get_response_data_item_relationships_next_part_data.py
+++ b/polarion_rest_api_client/open_api_client/models/document_parts_list_get_response_data_item_relationships_next_part_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_parts_list_get_response_data_item_relationships_next_part_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/document_parts_list_get_response_data_item_relationships_next_part_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/document_parts_list_get_response_data_item_relationships_previous_part.py
+++ b/polarion_rest_api_client/open_api_client/models/document_parts_list_get_response_data_item_relationships_previous_part.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_parts_list_get_response_data_item_relationships_previous_part_data.py
+++ b/polarion_rest_api_client/open_api_client/models/document_parts_list_get_response_data_item_relationships_previous_part_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_parts_list_get_response_data_item_relationships_previous_part_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/document_parts_list_get_response_data_item_relationships_previous_part_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/document_parts_list_get_response_data_item_relationships_work_item.py
+++ b/polarion_rest_api_client/open_api_client/models/document_parts_list_get_response_data_item_relationships_work_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_parts_list_get_response_data_item_relationships_work_item_data.py
+++ b/polarion_rest_api_client/open_api_client/models/document_parts_list_get_response_data_item_relationships_work_item_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_parts_list_get_response_data_item_relationships_work_item_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/document_parts_list_get_response_data_item_relationships_work_item_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/document_parts_list_get_response_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/document_parts_list_get_response_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/document_parts_list_get_response_included_item.py
+++ b/polarion_rest_api_client/open_api_client/models/document_parts_list_get_response_included_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar

--- a/polarion_rest_api_client/open_api_client/models/document_parts_list_get_response_links.py
+++ b/polarion_rest_api_client/open_api_client/models/document_parts_list_get_response_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_parts_list_get_response_meta.py
+++ b/polarion_rest_api_client/open_api_client/models/document_parts_list_get_response_meta.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_parts_list_post_request.py
+++ b/polarion_rest_api_client/open_api_client/models/document_parts_list_post_request.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_parts_list_post_request_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/document_parts_list_post_request_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_parts_list_post_request_data_item_attributes.py
+++ b/polarion_rest_api_client/open_api_client/models/document_parts_list_post_request_data_item_attributes.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_parts_list_post_request_data_item_relationships.py
+++ b/polarion_rest_api_client/open_api_client/models/document_parts_list_post_request_data_item_relationships.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_parts_list_post_request_data_item_relationships_next_part.py
+++ b/polarion_rest_api_client/open_api_client/models/document_parts_list_post_request_data_item_relationships_next_part.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_parts_list_post_request_data_item_relationships_next_part_data.py
+++ b/polarion_rest_api_client/open_api_client/models/document_parts_list_post_request_data_item_relationships_next_part_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_parts_list_post_request_data_item_relationships_next_part_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/document_parts_list_post_request_data_item_relationships_next_part_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/document_parts_list_post_request_data_item_relationships_previous_part.py
+++ b/polarion_rest_api_client/open_api_client/models/document_parts_list_post_request_data_item_relationships_previous_part.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_parts_list_post_request_data_item_relationships_previous_part_data.py
+++ b/polarion_rest_api_client/open_api_client/models/document_parts_list_post_request_data_item_relationships_previous_part_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_parts_list_post_request_data_item_relationships_previous_part_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/document_parts_list_post_request_data_item_relationships_previous_part_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/document_parts_list_post_request_data_item_relationships_work_item.py
+++ b/polarion_rest_api_client/open_api_client/models/document_parts_list_post_request_data_item_relationships_work_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_parts_list_post_request_data_item_relationships_work_item_data.py
+++ b/polarion_rest_api_client/open_api_client/models/document_parts_list_post_request_data_item_relationships_work_item_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_parts_list_post_request_data_item_relationships_work_item_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/document_parts_list_post_request_data_item_relationships_work_item_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/document_parts_list_post_request_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/document_parts_list_post_request_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/document_parts_list_post_response.py
+++ b/polarion_rest_api_client/open_api_client/models/document_parts_list_post_response.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_parts_list_post_response_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/document_parts_list_post_response_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_parts_list_post_response_data_item_links.py
+++ b/polarion_rest_api_client/open_api_client/models/document_parts_list_post_response_data_item_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_parts_list_post_response_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/document_parts_list_post_response_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/document_parts_single_get_response.py
+++ b/polarion_rest_api_client/open_api_client/models/document_parts_single_get_response.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_parts_single_get_response_data.py
+++ b/polarion_rest_api_client/open_api_client/models/document_parts_single_get_response_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_parts_single_get_response_data_attributes.py
+++ b/polarion_rest_api_client/open_api_client/models/document_parts_single_get_response_data_attributes.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_parts_single_get_response_data_links.py
+++ b/polarion_rest_api_client/open_api_client/models/document_parts_single_get_response_data_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_parts_single_get_response_data_meta.py
+++ b/polarion_rest_api_client/open_api_client/models/document_parts_single_get_response_data_meta.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_parts_single_get_response_data_meta_errors_item.py
+++ b/polarion_rest_api_client/open_api_client/models/document_parts_single_get_response_data_meta_errors_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_parts_single_get_response_data_meta_errors_item_source.py
+++ b/polarion_rest_api_client/open_api_client/models/document_parts_single_get_response_data_meta_errors_item_source.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_parts_single_get_response_data_relationships.py
+++ b/polarion_rest_api_client/open_api_client/models/document_parts_single_get_response_data_relationships.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_parts_single_get_response_data_relationships_next_part.py
+++ b/polarion_rest_api_client/open_api_client/models/document_parts_single_get_response_data_relationships_next_part.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_parts_single_get_response_data_relationships_next_part_data.py
+++ b/polarion_rest_api_client/open_api_client/models/document_parts_single_get_response_data_relationships_next_part_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_parts_single_get_response_data_relationships_next_part_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/document_parts_single_get_response_data_relationships_next_part_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/document_parts_single_get_response_data_relationships_previous_part.py
+++ b/polarion_rest_api_client/open_api_client/models/document_parts_single_get_response_data_relationships_previous_part.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_parts_single_get_response_data_relationships_previous_part_data.py
+++ b/polarion_rest_api_client/open_api_client/models/document_parts_single_get_response_data_relationships_previous_part_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_parts_single_get_response_data_relationships_previous_part_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/document_parts_single_get_response_data_relationships_previous_part_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/document_parts_single_get_response_data_relationships_work_item.py
+++ b/polarion_rest_api_client/open_api_client/models/document_parts_single_get_response_data_relationships_work_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_parts_single_get_response_data_relationships_work_item_data.py
+++ b/polarion_rest_api_client/open_api_client/models/document_parts_single_get_response_data_relationships_work_item_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/document_parts_single_get_response_data_relationships_work_item_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/document_parts_single_get_response_data_relationships_work_item_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/document_parts_single_get_response_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/document_parts_single_get_response_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/document_parts_single_get_response_included_item.py
+++ b/polarion_rest_api_client/open_api_client/models/document_parts_single_get_response_included_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar

--- a/polarion_rest_api_client/open_api_client/models/document_parts_single_get_response_links.py
+++ b/polarion_rest_api_client/open_api_client/models/document_parts_single_get_response_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/documents_list_post_request.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_list_post_request.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/documents_list_post_request_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_list_post_request_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/documents_list_post_request_data_item_attributes.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_list_post_request_data_item_attributes.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/documents_list_post_request_data_item_attributes_home_page_content.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_list_post_request_data_item_attributes_home_page_content.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/documents_list_post_request_data_item_attributes_home_page_content_type.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_list_post_request_data_item_attributes_home_page_content_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/documents_list_post_request_data_item_attributes_outline_numbering.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_list_post_request_data_item_attributes_outline_numbering.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/documents_list_post_request_data_item_attributes_rendering_layouts_item.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_list_post_request_data_item_attributes_rendering_layouts_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/documents_list_post_request_data_item_attributes_rendering_layouts_item_properties_item.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_list_post_request_data_item_attributes_rendering_layouts_item_properties_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/documents_list_post_request_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_list_post_request_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/documents_list_post_response.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_list_post_response.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/documents_list_post_response_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_list_post_response_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/documents_list_post_response_data_item_links.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_list_post_response_data_item_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/documents_list_post_response_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_list_post_response_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/documents_single_get_response.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_single_get_response.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_attributes.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_attributes.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 import datetime

--- a/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_attributes_home_page_content.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_attributes_home_page_content.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_attributes_home_page_content_type.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_attributes_home_page_content_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_attributes_outline_numbering.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_attributes_outline_numbering.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_attributes_rendering_layouts_item.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_attributes_rendering_layouts_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_attributes_rendering_layouts_item_properties_item.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_attributes_rendering_layouts_item_properties_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_links.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_meta.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_meta.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_meta_errors_item.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_meta_errors_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_meta_errors_item_source.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_meta_errors_item_source.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_relationships.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_relationships.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_relationships_attachments.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_relationships_attachments.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_relationships_attachments_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_relationships_attachments_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_relationships_attachments_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_relationships_attachments_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_relationships_attachments_links.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_relationships_attachments_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_relationships_attachments_meta.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_relationships_attachments_meta.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_relationships_author.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_relationships_author.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_relationships_author_data.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_relationships_author_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_relationships_author_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_relationships_author_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_relationships_branched_from.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_relationships_branched_from.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_relationships_branched_from_data.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_relationships_branched_from_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_relationships_branched_from_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_relationships_branched_from_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_relationships_comments.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_relationships_comments.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_relationships_comments_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_relationships_comments_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_relationships_comments_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_relationships_comments_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_relationships_comments_links.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_relationships_comments_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_relationships_comments_meta.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_relationships_comments_meta.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_relationships_derived_from.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_relationships_derived_from.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_relationships_derived_from_data.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_relationships_derived_from_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_relationships_derived_from_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_relationships_derived_from_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_relationships_project.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_relationships_project.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_relationships_project_data.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_relationships_project_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_relationships_project_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_relationships_project_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_relationships_updated_by.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_relationships_updated_by.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_relationships_updated_by_data.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_relationships_updated_by_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_relationships_updated_by_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_relationships_updated_by_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_relationships_variant.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_relationships_variant.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_relationships_variant_data.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_relationships_variant_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_relationships_variant_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_relationships_variant_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_single_get_response_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/documents_single_get_response_included_item.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_single_get_response_included_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar

--- a/polarion_rest_api_client/open_api_client/models/documents_single_get_response_links.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_single_get_response_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/documents_single_patch_request.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_single_patch_request.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/documents_single_patch_request_data.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_single_patch_request_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/documents_single_patch_request_data_attributes.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_single_patch_request_data_attributes.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/documents_single_patch_request_data_attributes_home_page_content.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_single_patch_request_data_attributes_home_page_content.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/documents_single_patch_request_data_attributes_home_page_content_type.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_single_patch_request_data_attributes_home_page_content_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/documents_single_patch_request_data_attributes_outline_numbering.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_single_patch_request_data_attributes_outline_numbering.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/documents_single_patch_request_data_attributes_rendering_layouts_item.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_single_patch_request_data_attributes_rendering_layouts_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/documents_single_patch_request_data_attributes_rendering_layouts_item_properties_item.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_single_patch_request_data_attributes_rendering_layouts_item_properties_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/documents_single_patch_request_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_single_patch_request_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/documents_single_post_response.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_single_post_response.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/documents_single_post_response_data.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_single_post_response_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/documents_single_post_response_data_attributes.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_single_post_response_data_attributes.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/documents_single_post_response_data_attributes_home_page_content.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_single_post_response_data_attributes_home_page_content.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/documents_single_post_response_data_attributes_home_page_content_type.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_single_post_response_data_attributes_home_page_content_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/documents_single_post_response_data_attributes_outline_numbering.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_single_post_response_data_attributes_outline_numbering.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/documents_single_post_response_data_attributes_rendering_layouts_item.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_single_post_response_data_attributes_rendering_layouts_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/documents_single_post_response_data_attributes_rendering_layouts_item_properties_item.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_single_post_response_data_attributes_rendering_layouts_item_properties_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/documents_single_post_response_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/documents_single_post_response_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/enum_options_action_response_body.py
+++ b/polarion_rest_api_client/open_api_client/models/enum_options_action_response_body.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/enum_options_action_response_body_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/enum_options_action_response_body_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/enum_options_action_response_body_links.py
+++ b/polarion_rest_api_client/open_api_client/models/enum_options_action_response_body_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/enum_options_action_response_body_meta.py
+++ b/polarion_rest_api_client/open_api_client/models/enum_options_action_response_body_meta.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/enumerations_list_post_request.py
+++ b/polarion_rest_api_client/open_api_client/models/enumerations_list_post_request.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/enumerations_list_post_request_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/enumerations_list_post_request_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/enumerations_list_post_request_data_item_attributes.py
+++ b/polarion_rest_api_client/open_api_client/models/enumerations_list_post_request_data_item_attributes.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/enumerations_list_post_request_data_item_attributes_options_item.py
+++ b/polarion_rest_api_client/open_api_client/models/enumerations_list_post_request_data_item_attributes_options_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/enumerations_list_post_request_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/enumerations_list_post_request_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/enumerations_list_post_response.py
+++ b/polarion_rest_api_client/open_api_client/models/enumerations_list_post_response.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/enumerations_list_post_response_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/enumerations_list_post_response_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/enumerations_list_post_response_data_item_links.py
+++ b/polarion_rest_api_client/open_api_client/models/enumerations_list_post_response_data_item_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/enumerations_list_post_response_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/enumerations_list_post_response_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/enumerations_single_get_response.py
+++ b/polarion_rest_api_client/open_api_client/models/enumerations_single_get_response.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/enumerations_single_get_response_data.py
+++ b/polarion_rest_api_client/open_api_client/models/enumerations_single_get_response_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/enumerations_single_get_response_data_attributes.py
+++ b/polarion_rest_api_client/open_api_client/models/enumerations_single_get_response_data_attributes.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/enumerations_single_get_response_data_attributes_options_item.py
+++ b/polarion_rest_api_client/open_api_client/models/enumerations_single_get_response_data_attributes_options_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/enumerations_single_get_response_data_links.py
+++ b/polarion_rest_api_client/open_api_client/models/enumerations_single_get_response_data_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/enumerations_single_get_response_data_meta.py
+++ b/polarion_rest_api_client/open_api_client/models/enumerations_single_get_response_data_meta.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/enumerations_single_get_response_data_meta_errors_item.py
+++ b/polarion_rest_api_client/open_api_client/models/enumerations_single_get_response_data_meta_errors_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/enumerations_single_get_response_data_meta_errors_item_source.py
+++ b/polarion_rest_api_client/open_api_client/models/enumerations_single_get_response_data_meta_errors_item_source.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/enumerations_single_get_response_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/enumerations_single_get_response_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/enumerations_single_get_response_included_item.py
+++ b/polarion_rest_api_client/open_api_client/models/enumerations_single_get_response_included_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar

--- a/polarion_rest_api_client/open_api_client/models/enumerations_single_get_response_links.py
+++ b/polarion_rest_api_client/open_api_client/models/enumerations_single_get_response_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/enumerations_single_patch_request.py
+++ b/polarion_rest_api_client/open_api_client/models/enumerations_single_patch_request.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/enumerations_single_patch_request_data.py
+++ b/polarion_rest_api_client/open_api_client/models/enumerations_single_patch_request_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/enumerations_single_patch_request_data_attributes.py
+++ b/polarion_rest_api_client/open_api_client/models/enumerations_single_patch_request_data_attributes.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/enumerations_single_patch_request_data_attributes_options_item.py
+++ b/polarion_rest_api_client/open_api_client/models/enumerations_single_patch_request_data_attributes_options_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/enumerations_single_patch_request_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/enumerations_single_patch_request_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/errors.py
+++ b/polarion_rest_api_client/open_api_client/models/errors.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/errors_errors_item.py
+++ b/polarion_rest_api_client/open_api_client/models/errors_errors_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/errors_errors_item_source.py
+++ b/polarion_rest_api_client/open_api_client/models/errors_errors_item_source.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/globalroles_single_get_response.py
+++ b/polarion_rest_api_client/open_api_client/models/globalroles_single_get_response.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/globalroles_single_get_response_data.py
+++ b/polarion_rest_api_client/open_api_client/models/globalroles_single_get_response_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/globalroles_single_get_response_data_links.py
+++ b/polarion_rest_api_client/open_api_client/models/globalroles_single_get_response_data_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/globalroles_single_get_response_data_meta.py
+++ b/polarion_rest_api_client/open_api_client/models/globalroles_single_get_response_data_meta.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/globalroles_single_get_response_data_meta_errors_item.py
+++ b/polarion_rest_api_client/open_api_client/models/globalroles_single_get_response_data_meta_errors_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/globalroles_single_get_response_data_meta_errors_item_source.py
+++ b/polarion_rest_api_client/open_api_client/models/globalroles_single_get_response_data_meta_errors_item_source.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/globalroles_single_get_response_data_relationships.py
+++ b/polarion_rest_api_client/open_api_client/models/globalroles_single_get_response_data_relationships.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/globalroles_single_get_response_data_relationships_users.py
+++ b/polarion_rest_api_client/open_api_client/models/globalroles_single_get_response_data_relationships_users.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/globalroles_single_get_response_data_relationships_users_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/globalroles_single_get_response_data_relationships_users_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/globalroles_single_get_response_data_relationships_users_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/globalroles_single_get_response_data_relationships_users_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/globalroles_single_get_response_data_relationships_users_meta.py
+++ b/polarion_rest_api_client/open_api_client/models/globalroles_single_get_response_data_relationships_users_meta.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/globalroles_single_get_response_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/globalroles_single_get_response_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/globalroles_single_get_response_included_item.py
+++ b/polarion_rest_api_client/open_api_client/models/globalroles_single_get_response_included_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar

--- a/polarion_rest_api_client/open_api_client/models/globalroles_single_get_response_links.py
+++ b/polarion_rest_api_client/open_api_client/models/globalroles_single_get_response_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/icons_list_get_response.py
+++ b/polarion_rest_api_client/open_api_client/models/icons_list_get_response.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/icons_list_get_response_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/icons_list_get_response_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/icons_list_get_response_data_item_attributes.py
+++ b/polarion_rest_api_client/open_api_client/models/icons_list_get_response_data_item_attributes.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/icons_list_get_response_data_item_links.py
+++ b/polarion_rest_api_client/open_api_client/models/icons_list_get_response_data_item_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/icons_list_get_response_data_item_meta.py
+++ b/polarion_rest_api_client/open_api_client/models/icons_list_get_response_data_item_meta.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/icons_list_get_response_data_item_meta_errors_item.py
+++ b/polarion_rest_api_client/open_api_client/models/icons_list_get_response_data_item_meta_errors_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/icons_list_get_response_data_item_meta_errors_item_source.py
+++ b/polarion_rest_api_client/open_api_client/models/icons_list_get_response_data_item_meta_errors_item_source.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/icons_list_get_response_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/icons_list_get_response_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/icons_list_get_response_included_item.py
+++ b/polarion_rest_api_client/open_api_client/models/icons_list_get_response_included_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar

--- a/polarion_rest_api_client/open_api_client/models/icons_list_get_response_links.py
+++ b/polarion_rest_api_client/open_api_client/models/icons_list_get_response_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/icons_list_get_response_meta.py
+++ b/polarion_rest_api_client/open_api_client/models/icons_list_get_response_meta.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/icons_single_get_response.py
+++ b/polarion_rest_api_client/open_api_client/models/icons_single_get_response.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/icons_single_get_response_data.py
+++ b/polarion_rest_api_client/open_api_client/models/icons_single_get_response_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/icons_single_get_response_data_attributes.py
+++ b/polarion_rest_api_client/open_api_client/models/icons_single_get_response_data_attributes.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/icons_single_get_response_data_links.py
+++ b/polarion_rest_api_client/open_api_client/models/icons_single_get_response_data_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/icons_single_get_response_data_meta.py
+++ b/polarion_rest_api_client/open_api_client/models/icons_single_get_response_data_meta.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/icons_single_get_response_data_meta_errors_item.py
+++ b/polarion_rest_api_client/open_api_client/models/icons_single_get_response_data_meta_errors_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/icons_single_get_response_data_meta_errors_item_source.py
+++ b/polarion_rest_api_client/open_api_client/models/icons_single_get_response_data_meta_errors_item_source.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/icons_single_get_response_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/icons_single_get_response_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/icons_single_get_response_included_item.py
+++ b/polarion_rest_api_client/open_api_client/models/icons_single_get_response_included_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar

--- a/polarion_rest_api_client/open_api_client/models/icons_single_get_response_links.py
+++ b/polarion_rest_api_client/open_api_client/models/icons_single_get_response_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/linkedworkitems_list_delete_request.py
+++ b/polarion_rest_api_client/open_api_client/models/linkedworkitems_list_delete_request.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/linkedworkitems_list_delete_request_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/linkedworkitems_list_delete_request_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/linkedworkitems_list_delete_request_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/linkedworkitems_list_delete_request_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/linkedworkitems_list_get_response.py
+++ b/polarion_rest_api_client/open_api_client/models/linkedworkitems_list_get_response.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/linkedworkitems_list_get_response_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/linkedworkitems_list_get_response_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/linkedworkitems_list_get_response_data_item_attributes.py
+++ b/polarion_rest_api_client/open_api_client/models/linkedworkitems_list_get_response_data_item_attributes.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/linkedworkitems_list_get_response_data_item_links.py
+++ b/polarion_rest_api_client/open_api_client/models/linkedworkitems_list_get_response_data_item_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/linkedworkitems_list_get_response_data_item_meta.py
+++ b/polarion_rest_api_client/open_api_client/models/linkedworkitems_list_get_response_data_item_meta.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/linkedworkitems_list_get_response_data_item_meta_errors_item.py
+++ b/polarion_rest_api_client/open_api_client/models/linkedworkitems_list_get_response_data_item_meta_errors_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/linkedworkitems_list_get_response_data_item_meta_errors_item_source.py
+++ b/polarion_rest_api_client/open_api_client/models/linkedworkitems_list_get_response_data_item_meta_errors_item_source.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/linkedworkitems_list_get_response_data_item_relationships.py
+++ b/polarion_rest_api_client/open_api_client/models/linkedworkitems_list_get_response_data_item_relationships.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/linkedworkitems_list_get_response_data_item_relationships_work_item.py
+++ b/polarion_rest_api_client/open_api_client/models/linkedworkitems_list_get_response_data_item_relationships_work_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/linkedworkitems_list_get_response_data_item_relationships_work_item_data.py
+++ b/polarion_rest_api_client/open_api_client/models/linkedworkitems_list_get_response_data_item_relationships_work_item_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/linkedworkitems_list_get_response_data_item_relationships_work_item_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/linkedworkitems_list_get_response_data_item_relationships_work_item_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/linkedworkitems_list_get_response_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/linkedworkitems_list_get_response_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/linkedworkitems_list_get_response_included_item.py
+++ b/polarion_rest_api_client/open_api_client/models/linkedworkitems_list_get_response_included_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar

--- a/polarion_rest_api_client/open_api_client/models/linkedworkitems_list_get_response_links.py
+++ b/polarion_rest_api_client/open_api_client/models/linkedworkitems_list_get_response_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/linkedworkitems_list_get_response_meta.py
+++ b/polarion_rest_api_client/open_api_client/models/linkedworkitems_list_get_response_meta.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/linkedworkitems_list_post_request.py
+++ b/polarion_rest_api_client/open_api_client/models/linkedworkitems_list_post_request.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/linkedworkitems_list_post_request_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/linkedworkitems_list_post_request_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/linkedworkitems_list_post_request_data_item_attributes.py
+++ b/polarion_rest_api_client/open_api_client/models/linkedworkitems_list_post_request_data_item_attributes.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/linkedworkitems_list_post_request_data_item_relationships.py
+++ b/polarion_rest_api_client/open_api_client/models/linkedworkitems_list_post_request_data_item_relationships.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/linkedworkitems_list_post_request_data_item_relationships_work_item.py
+++ b/polarion_rest_api_client/open_api_client/models/linkedworkitems_list_post_request_data_item_relationships_work_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/linkedworkitems_list_post_request_data_item_relationships_work_item_data.py
+++ b/polarion_rest_api_client/open_api_client/models/linkedworkitems_list_post_request_data_item_relationships_work_item_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/linkedworkitems_list_post_request_data_item_relationships_work_item_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/linkedworkitems_list_post_request_data_item_relationships_work_item_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/linkedworkitems_list_post_request_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/linkedworkitems_list_post_request_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/linkedworkitems_list_post_response.py
+++ b/polarion_rest_api_client/open_api_client/models/linkedworkitems_list_post_response.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/linkedworkitems_list_post_response_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/linkedworkitems_list_post_response_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/linkedworkitems_list_post_response_data_item_links.py
+++ b/polarion_rest_api_client/open_api_client/models/linkedworkitems_list_post_response_data_item_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/linkedworkitems_list_post_response_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/linkedworkitems_list_post_response_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/linkedworkitems_single_get_response.py
+++ b/polarion_rest_api_client/open_api_client/models/linkedworkitems_single_get_response.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/linkedworkitems_single_get_response_data.py
+++ b/polarion_rest_api_client/open_api_client/models/linkedworkitems_single_get_response_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/linkedworkitems_single_get_response_data_attributes.py
+++ b/polarion_rest_api_client/open_api_client/models/linkedworkitems_single_get_response_data_attributes.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/linkedworkitems_single_get_response_data_links.py
+++ b/polarion_rest_api_client/open_api_client/models/linkedworkitems_single_get_response_data_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/linkedworkitems_single_get_response_data_meta.py
+++ b/polarion_rest_api_client/open_api_client/models/linkedworkitems_single_get_response_data_meta.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/linkedworkitems_single_get_response_data_meta_errors_item.py
+++ b/polarion_rest_api_client/open_api_client/models/linkedworkitems_single_get_response_data_meta_errors_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/linkedworkitems_single_get_response_data_meta_errors_item_source.py
+++ b/polarion_rest_api_client/open_api_client/models/linkedworkitems_single_get_response_data_meta_errors_item_source.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/linkedworkitems_single_get_response_data_relationships.py
+++ b/polarion_rest_api_client/open_api_client/models/linkedworkitems_single_get_response_data_relationships.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/linkedworkitems_single_get_response_data_relationships_work_item.py
+++ b/polarion_rest_api_client/open_api_client/models/linkedworkitems_single_get_response_data_relationships_work_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/linkedworkitems_single_get_response_data_relationships_work_item_data.py
+++ b/polarion_rest_api_client/open_api_client/models/linkedworkitems_single_get_response_data_relationships_work_item_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/linkedworkitems_single_get_response_data_relationships_work_item_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/linkedworkitems_single_get_response_data_relationships_work_item_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/linkedworkitems_single_get_response_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/linkedworkitems_single_get_response_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/linkedworkitems_single_get_response_included_item.py
+++ b/polarion_rest_api_client/open_api_client/models/linkedworkitems_single_get_response_included_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar

--- a/polarion_rest_api_client/open_api_client/models/linkedworkitems_single_get_response_links.py
+++ b/polarion_rest_api_client/open_api_client/models/linkedworkitems_single_get_response_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/linkedworkitems_single_patch_request.py
+++ b/polarion_rest_api_client/open_api_client/models/linkedworkitems_single_patch_request.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/linkedworkitems_single_patch_request_data.py
+++ b/polarion_rest_api_client/open_api_client/models/linkedworkitems_single_patch_request_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/linkedworkitems_single_patch_request_data_attributes.py
+++ b/polarion_rest_api_client/open_api_client/models/linkedworkitems_single_patch_request_data_attributes.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/linkedworkitems_single_patch_request_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/linkedworkitems_single_patch_request_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/move_work_item_to_document_request_body.py
+++ b/polarion_rest_api_client/open_api_client/models/move_work_item_to_document_request_body.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/page_attachments_list_post_request.py
+++ b/polarion_rest_api_client/open_api_client/models/page_attachments_list_post_request.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/page_attachments_list_post_request_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/page_attachments_list_post_request_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/page_attachments_list_post_request_data_item_attributes.py
+++ b/polarion_rest_api_client/open_api_client/models/page_attachments_list_post_request_data_item_attributes.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/page_attachments_list_post_request_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/page_attachments_list_post_request_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/page_attachments_list_post_response.py
+++ b/polarion_rest_api_client/open_api_client/models/page_attachments_list_post_response.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/page_attachments_list_post_response_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/page_attachments_list_post_response_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/page_attachments_list_post_response_data_item_links.py
+++ b/polarion_rest_api_client/open_api_client/models/page_attachments_list_post_response_data_item_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/page_attachments_list_post_response_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/page_attachments_list_post_response_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/page_attachments_single_get_response.py
+++ b/polarion_rest_api_client/open_api_client/models/page_attachments_single_get_response.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/page_attachments_single_get_response_data.py
+++ b/polarion_rest_api_client/open_api_client/models/page_attachments_single_get_response_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/page_attachments_single_get_response_data_attributes.py
+++ b/polarion_rest_api_client/open_api_client/models/page_attachments_single_get_response_data_attributes.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 import datetime

--- a/polarion_rest_api_client/open_api_client/models/page_attachments_single_get_response_data_links.py
+++ b/polarion_rest_api_client/open_api_client/models/page_attachments_single_get_response_data_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/page_attachments_single_get_response_data_meta.py
+++ b/polarion_rest_api_client/open_api_client/models/page_attachments_single_get_response_data_meta.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/page_attachments_single_get_response_data_meta_errors_item.py
+++ b/polarion_rest_api_client/open_api_client/models/page_attachments_single_get_response_data_meta_errors_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/page_attachments_single_get_response_data_meta_errors_item_source.py
+++ b/polarion_rest_api_client/open_api_client/models/page_attachments_single_get_response_data_meta_errors_item_source.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/page_attachments_single_get_response_data_relationships.py
+++ b/polarion_rest_api_client/open_api_client/models/page_attachments_single_get_response_data_relationships.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/page_attachments_single_get_response_data_relationships_author.py
+++ b/polarion_rest_api_client/open_api_client/models/page_attachments_single_get_response_data_relationships_author.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/page_attachments_single_get_response_data_relationships_author_data.py
+++ b/polarion_rest_api_client/open_api_client/models/page_attachments_single_get_response_data_relationships_author_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/page_attachments_single_get_response_data_relationships_author_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/page_attachments_single_get_response_data_relationships_author_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/page_attachments_single_get_response_data_relationships_project.py
+++ b/polarion_rest_api_client/open_api_client/models/page_attachments_single_get_response_data_relationships_project.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/page_attachments_single_get_response_data_relationships_project_data.py
+++ b/polarion_rest_api_client/open_api_client/models/page_attachments_single_get_response_data_relationships_project_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/page_attachments_single_get_response_data_relationships_project_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/page_attachments_single_get_response_data_relationships_project_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/page_attachments_single_get_response_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/page_attachments_single_get_response_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/page_attachments_single_get_response_included_item.py
+++ b/polarion_rest_api_client/open_api_client/models/page_attachments_single_get_response_included_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar

--- a/polarion_rest_api_client/open_api_client/models/page_attachments_single_get_response_links.py
+++ b/polarion_rest_api_client/open_api_client/models/page_attachments_single_get_response_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/pages_single_get_response.py
+++ b/polarion_rest_api_client/open_api_client/models/pages_single_get_response.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/pages_single_get_response_data.py
+++ b/polarion_rest_api_client/open_api_client/models/pages_single_get_response_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/pages_single_get_response_data_attributes.py
+++ b/polarion_rest_api_client/open_api_client/models/pages_single_get_response_data_attributes.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 import datetime

--- a/polarion_rest_api_client/open_api_client/models/pages_single_get_response_data_links.py
+++ b/polarion_rest_api_client/open_api_client/models/pages_single_get_response_data_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/pages_single_get_response_data_meta.py
+++ b/polarion_rest_api_client/open_api_client/models/pages_single_get_response_data_meta.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/pages_single_get_response_data_meta_errors_item.py
+++ b/polarion_rest_api_client/open_api_client/models/pages_single_get_response_data_meta_errors_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/pages_single_get_response_data_meta_errors_item_source.py
+++ b/polarion_rest_api_client/open_api_client/models/pages_single_get_response_data_meta_errors_item_source.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/pages_single_get_response_data_relationships.py
+++ b/polarion_rest_api_client/open_api_client/models/pages_single_get_response_data_relationships.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/pages_single_get_response_data_relationships_attachments.py
+++ b/polarion_rest_api_client/open_api_client/models/pages_single_get_response_data_relationships_attachments.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/pages_single_get_response_data_relationships_attachments_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/pages_single_get_response_data_relationships_attachments_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/pages_single_get_response_data_relationships_attachments_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/pages_single_get_response_data_relationships_attachments_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/pages_single_get_response_data_relationships_attachments_meta.py
+++ b/polarion_rest_api_client/open_api_client/models/pages_single_get_response_data_relationships_attachments_meta.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/pages_single_get_response_data_relationships_author.py
+++ b/polarion_rest_api_client/open_api_client/models/pages_single_get_response_data_relationships_author.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/pages_single_get_response_data_relationships_author_data.py
+++ b/polarion_rest_api_client/open_api_client/models/pages_single_get_response_data_relationships_author_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/pages_single_get_response_data_relationships_author_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/pages_single_get_response_data_relationships_author_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/pages_single_get_response_data_relationships_project.py
+++ b/polarion_rest_api_client/open_api_client/models/pages_single_get_response_data_relationships_project.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/pages_single_get_response_data_relationships_project_data.py
+++ b/polarion_rest_api_client/open_api_client/models/pages_single_get_response_data_relationships_project_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/pages_single_get_response_data_relationships_project_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/pages_single_get_response_data_relationships_project_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/pages_single_get_response_data_relationships_updated_by.py
+++ b/polarion_rest_api_client/open_api_client/models/pages_single_get_response_data_relationships_updated_by.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/pages_single_get_response_data_relationships_updated_by_data.py
+++ b/polarion_rest_api_client/open_api_client/models/pages_single_get_response_data_relationships_updated_by_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/pages_single_get_response_data_relationships_updated_by_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/pages_single_get_response_data_relationships_updated_by_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/pages_single_get_response_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/pages_single_get_response_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/pages_single_get_response_included_item.py
+++ b/polarion_rest_api_client/open_api_client/models/pages_single_get_response_included_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar

--- a/polarion_rest_api_client/open_api_client/models/pages_single_get_response_links.py
+++ b/polarion_rest_api_client/open_api_client/models/pages_single_get_response_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/pages_single_patch_request.py
+++ b/polarion_rest_api_client/open_api_client/models/pages_single_patch_request.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/pages_single_patch_request_data.py
+++ b/polarion_rest_api_client/open_api_client/models/pages_single_patch_request_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/pages_single_patch_request_data_attributes.py
+++ b/polarion_rest_api_client/open_api_client/models/pages_single_patch_request_data_attributes.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/pages_single_patch_request_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/pages_single_patch_request_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/pagination.py
+++ b/polarion_rest_api_client/open_api_client/models/pagination.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/patch_document_attachments_request_body.py
+++ b/polarion_rest_api_client/open_api_client/models/patch_document_attachments_request_body.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 import json

--- a/polarion_rest_api_client/open_api_client/models/patch_work_item_attachments_request_body.py
+++ b/polarion_rest_api_client/open_api_client/models/patch_work_item_attachments_request_body.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 import json

--- a/polarion_rest_api_client/open_api_client/models/post_document_attachments_request_body.py
+++ b/polarion_rest_api_client/open_api_client/models/post_document_attachments_request_body.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 import json

--- a/polarion_rest_api_client/open_api_client/models/post_page_attachments_request_body.py
+++ b/polarion_rest_api_client/open_api_client/models/post_page_attachments_request_body.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 import json

--- a/polarion_rest_api_client/open_api_client/models/post_work_item_attachments_request_body.py
+++ b/polarion_rest_api_client/open_api_client/models/post_work_item_attachments_request_body.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 import json

--- a/polarion_rest_api_client/open_api_client/models/projects_list_get_response.py
+++ b/polarion_rest_api_client/open_api_client/models/projects_list_get_response.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/projects_list_get_response_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/projects_list_get_response_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/projects_list_get_response_data_item_attributes.py
+++ b/polarion_rest_api_client/open_api_client/models/projects_list_get_response_data_item_attributes.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 import datetime

--- a/polarion_rest_api_client/open_api_client/models/projects_list_get_response_data_item_attributes_description.py
+++ b/polarion_rest_api_client/open_api_client/models/projects_list_get_response_data_item_attributes_description.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/projects_list_get_response_data_item_attributes_description_type.py
+++ b/polarion_rest_api_client/open_api_client/models/projects_list_get_response_data_item_attributes_description_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/projects_list_get_response_data_item_links.py
+++ b/polarion_rest_api_client/open_api_client/models/projects_list_get_response_data_item_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/projects_list_get_response_data_item_meta.py
+++ b/polarion_rest_api_client/open_api_client/models/projects_list_get_response_data_item_meta.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/projects_list_get_response_data_item_meta_errors_item.py
+++ b/polarion_rest_api_client/open_api_client/models/projects_list_get_response_data_item_meta_errors_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/projects_list_get_response_data_item_meta_errors_item_source.py
+++ b/polarion_rest_api_client/open_api_client/models/projects_list_get_response_data_item_meta_errors_item_source.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/projects_list_get_response_data_item_relationships.py
+++ b/polarion_rest_api_client/open_api_client/models/projects_list_get_response_data_item_relationships.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/projects_list_get_response_data_item_relationships_lead.py
+++ b/polarion_rest_api_client/open_api_client/models/projects_list_get_response_data_item_relationships_lead.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/projects_list_get_response_data_item_relationships_lead_data.py
+++ b/polarion_rest_api_client/open_api_client/models/projects_list_get_response_data_item_relationships_lead_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/projects_list_get_response_data_item_relationships_lead_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/projects_list_get_response_data_item_relationships_lead_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/projects_list_get_response_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/projects_list_get_response_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/projects_list_get_response_included_item.py
+++ b/polarion_rest_api_client/open_api_client/models/projects_list_get_response_included_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar

--- a/polarion_rest_api_client/open_api_client/models/projects_list_get_response_links.py
+++ b/polarion_rest_api_client/open_api_client/models/projects_list_get_response_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/projects_list_get_response_meta.py
+++ b/polarion_rest_api_client/open_api_client/models/projects_list_get_response_meta.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/projects_single_get_response.py
+++ b/polarion_rest_api_client/open_api_client/models/projects_single_get_response.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/projects_single_get_response_data.py
+++ b/polarion_rest_api_client/open_api_client/models/projects_single_get_response_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/projects_single_get_response_data_attributes.py
+++ b/polarion_rest_api_client/open_api_client/models/projects_single_get_response_data_attributes.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 import datetime

--- a/polarion_rest_api_client/open_api_client/models/projects_single_get_response_data_attributes_description.py
+++ b/polarion_rest_api_client/open_api_client/models/projects_single_get_response_data_attributes_description.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/projects_single_get_response_data_attributes_description_type.py
+++ b/polarion_rest_api_client/open_api_client/models/projects_single_get_response_data_attributes_description_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/projects_single_get_response_data_links.py
+++ b/polarion_rest_api_client/open_api_client/models/projects_single_get_response_data_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/projects_single_get_response_data_meta.py
+++ b/polarion_rest_api_client/open_api_client/models/projects_single_get_response_data_meta.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/projects_single_get_response_data_meta_errors_item.py
+++ b/polarion_rest_api_client/open_api_client/models/projects_single_get_response_data_meta_errors_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/projects_single_get_response_data_meta_errors_item_source.py
+++ b/polarion_rest_api_client/open_api_client/models/projects_single_get_response_data_meta_errors_item_source.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/projects_single_get_response_data_relationships.py
+++ b/polarion_rest_api_client/open_api_client/models/projects_single_get_response_data_relationships.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/projects_single_get_response_data_relationships_lead.py
+++ b/polarion_rest_api_client/open_api_client/models/projects_single_get_response_data_relationships_lead.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/projects_single_get_response_data_relationships_lead_data.py
+++ b/polarion_rest_api_client/open_api_client/models/projects_single_get_response_data_relationships_lead_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/projects_single_get_response_data_relationships_lead_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/projects_single_get_response_data_relationships_lead_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/projects_single_get_response_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/projects_single_get_response_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/projects_single_get_response_included_item.py
+++ b/polarion_rest_api_client/open_api_client/models/projects_single_get_response_included_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar

--- a/polarion_rest_api_client/open_api_client/models/projects_single_get_response_links.py
+++ b/polarion_rest_api_client/open_api_client/models/projects_single_get_response_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/resource_reference.py
+++ b/polarion_rest_api_client/open_api_client/models/resource_reference.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar

--- a/polarion_rest_api_client/open_api_client/models/set_license_request_body.py
+++ b/polarion_rest_api_client/open_api_client/models/set_license_request_body.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/set_license_request_body_license.py
+++ b/polarion_rest_api_client/open_api_client/models/set_license_request_body_license.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/sparse_fields.py
+++ b/polarion_rest_api_client/open_api_client/models/sparse_fields.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/usergroups_single_get_response.py
+++ b/polarion_rest_api_client/open_api_client/models/usergroups_single_get_response.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/usergroups_single_get_response_data.py
+++ b/polarion_rest_api_client/open_api_client/models/usergroups_single_get_response_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/usergroups_single_get_response_data_attributes.py
+++ b/polarion_rest_api_client/open_api_client/models/usergroups_single_get_response_data_attributes.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/usergroups_single_get_response_data_attributes_description.py
+++ b/polarion_rest_api_client/open_api_client/models/usergroups_single_get_response_data_attributes_description.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/usergroups_single_get_response_data_attributes_description_type.py
+++ b/polarion_rest_api_client/open_api_client/models/usergroups_single_get_response_data_attributes_description_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/usergroups_single_get_response_data_links.py
+++ b/polarion_rest_api_client/open_api_client/models/usergroups_single_get_response_data_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/usergroups_single_get_response_data_meta.py
+++ b/polarion_rest_api_client/open_api_client/models/usergroups_single_get_response_data_meta.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/usergroups_single_get_response_data_meta_errors_item.py
+++ b/polarion_rest_api_client/open_api_client/models/usergroups_single_get_response_data_meta_errors_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/usergroups_single_get_response_data_meta_errors_item_source.py
+++ b/polarion_rest_api_client/open_api_client/models/usergroups_single_get_response_data_meta_errors_item_source.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/usergroups_single_get_response_data_relationships.py
+++ b/polarion_rest_api_client/open_api_client/models/usergroups_single_get_response_data_relationships.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/usergroups_single_get_response_data_relationships_global_roles.py
+++ b/polarion_rest_api_client/open_api_client/models/usergroups_single_get_response_data_relationships_global_roles.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/usergroups_single_get_response_data_relationships_global_roles_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/usergroups_single_get_response_data_relationships_global_roles_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/usergroups_single_get_response_data_relationships_global_roles_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/usergroups_single_get_response_data_relationships_global_roles_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/usergroups_single_get_response_data_relationships_global_roles_meta.py
+++ b/polarion_rest_api_client/open_api_client/models/usergroups_single_get_response_data_relationships_global_roles_meta.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/usergroups_single_get_response_data_relationships_project_roles.py
+++ b/polarion_rest_api_client/open_api_client/models/usergroups_single_get_response_data_relationships_project_roles.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/usergroups_single_get_response_data_relationships_project_roles_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/usergroups_single_get_response_data_relationships_project_roles_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/usergroups_single_get_response_data_relationships_project_roles_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/usergroups_single_get_response_data_relationships_project_roles_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/usergroups_single_get_response_data_relationships_project_roles_meta.py
+++ b/polarion_rest_api_client/open_api_client/models/usergroups_single_get_response_data_relationships_project_roles_meta.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/usergroups_single_get_response_data_relationships_users.py
+++ b/polarion_rest_api_client/open_api_client/models/usergroups_single_get_response_data_relationships_users.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/usergroups_single_get_response_data_relationships_users_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/usergroups_single_get_response_data_relationships_users_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/usergroups_single_get_response_data_relationships_users_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/usergroups_single_get_response_data_relationships_users_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/usergroups_single_get_response_data_relationships_users_meta.py
+++ b/polarion_rest_api_client/open_api_client/models/usergroups_single_get_response_data_relationships_users_meta.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/usergroups_single_get_response_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/usergroups_single_get_response_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/usergroups_single_get_response_included_item.py
+++ b/polarion_rest_api_client/open_api_client/models/usergroups_single_get_response_included_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar

--- a/polarion_rest_api_client/open_api_client/models/usergroups_single_get_response_links.py
+++ b/polarion_rest_api_client/open_api_client/models/usergroups_single_get_response_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/users_list_get_response.py
+++ b/polarion_rest_api_client/open_api_client/models/users_list_get_response.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/users_list_get_response_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/users_list_get_response_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/users_list_get_response_data_item_attributes.py
+++ b/polarion_rest_api_client/open_api_client/models/users_list_get_response_data_item_attributes.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/users_list_get_response_data_item_attributes_description.py
+++ b/polarion_rest_api_client/open_api_client/models/users_list_get_response_data_item_attributes_description.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/users_list_get_response_data_item_attributes_description_type.py
+++ b/polarion_rest_api_client/open_api_client/models/users_list_get_response_data_item_attributes_description_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/users_list_get_response_data_item_links.py
+++ b/polarion_rest_api_client/open_api_client/models/users_list_get_response_data_item_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/users_list_get_response_data_item_meta.py
+++ b/polarion_rest_api_client/open_api_client/models/users_list_get_response_data_item_meta.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/users_list_get_response_data_item_meta_errors_item.py
+++ b/polarion_rest_api_client/open_api_client/models/users_list_get_response_data_item_meta_errors_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/users_list_get_response_data_item_meta_errors_item_source.py
+++ b/polarion_rest_api_client/open_api_client/models/users_list_get_response_data_item_meta_errors_item_source.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/users_list_get_response_data_item_relationships.py
+++ b/polarion_rest_api_client/open_api_client/models/users_list_get_response_data_item_relationships.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/users_list_get_response_data_item_relationships_global_roles.py
+++ b/polarion_rest_api_client/open_api_client/models/users_list_get_response_data_item_relationships_global_roles.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/users_list_get_response_data_item_relationships_global_roles_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/users_list_get_response_data_item_relationships_global_roles_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/users_list_get_response_data_item_relationships_global_roles_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/users_list_get_response_data_item_relationships_global_roles_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/users_list_get_response_data_item_relationships_global_roles_meta.py
+++ b/polarion_rest_api_client/open_api_client/models/users_list_get_response_data_item_relationships_global_roles_meta.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/users_list_get_response_data_item_relationships_project_roles.py
+++ b/polarion_rest_api_client/open_api_client/models/users_list_get_response_data_item_relationships_project_roles.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/users_list_get_response_data_item_relationships_project_roles_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/users_list_get_response_data_item_relationships_project_roles_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/users_list_get_response_data_item_relationships_project_roles_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/users_list_get_response_data_item_relationships_project_roles_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/users_list_get_response_data_item_relationships_project_roles_meta.py
+++ b/polarion_rest_api_client/open_api_client/models/users_list_get_response_data_item_relationships_project_roles_meta.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/users_list_get_response_data_item_relationships_user_groups.py
+++ b/polarion_rest_api_client/open_api_client/models/users_list_get_response_data_item_relationships_user_groups.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/users_list_get_response_data_item_relationships_user_groups_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/users_list_get_response_data_item_relationships_user_groups_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/users_list_get_response_data_item_relationships_user_groups_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/users_list_get_response_data_item_relationships_user_groups_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/users_list_get_response_data_item_relationships_user_groups_meta.py
+++ b/polarion_rest_api_client/open_api_client/models/users_list_get_response_data_item_relationships_user_groups_meta.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/users_list_get_response_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/users_list_get_response_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/users_list_get_response_included_item.py
+++ b/polarion_rest_api_client/open_api_client/models/users_list_get_response_included_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar

--- a/polarion_rest_api_client/open_api_client/models/users_list_get_response_links.py
+++ b/polarion_rest_api_client/open_api_client/models/users_list_get_response_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/users_list_get_response_meta.py
+++ b/polarion_rest_api_client/open_api_client/models/users_list_get_response_meta.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/users_list_post_request.py
+++ b/polarion_rest_api_client/open_api_client/models/users_list_post_request.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/users_list_post_request_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/users_list_post_request_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/users_list_post_request_data_item_attributes.py
+++ b/polarion_rest_api_client/open_api_client/models/users_list_post_request_data_item_attributes.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/users_list_post_request_data_item_attributes_description.py
+++ b/polarion_rest_api_client/open_api_client/models/users_list_post_request_data_item_attributes_description.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/users_list_post_request_data_item_attributes_description_type.py
+++ b/polarion_rest_api_client/open_api_client/models/users_list_post_request_data_item_attributes_description_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/users_list_post_request_data_item_relationships.py
+++ b/polarion_rest_api_client/open_api_client/models/users_list_post_request_data_item_relationships.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/users_list_post_request_data_item_relationships_global_roles.py
+++ b/polarion_rest_api_client/open_api_client/models/users_list_post_request_data_item_relationships_global_roles.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/users_list_post_request_data_item_relationships_global_roles_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/users_list_post_request_data_item_relationships_global_roles_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/users_list_post_request_data_item_relationships_global_roles_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/users_list_post_request_data_item_relationships_global_roles_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/users_list_post_request_data_item_relationships_project_roles.py
+++ b/polarion_rest_api_client/open_api_client/models/users_list_post_request_data_item_relationships_project_roles.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/users_list_post_request_data_item_relationships_project_roles_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/users_list_post_request_data_item_relationships_project_roles_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/users_list_post_request_data_item_relationships_project_roles_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/users_list_post_request_data_item_relationships_project_roles_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/users_list_post_request_data_item_relationships_user_groups.py
+++ b/polarion_rest_api_client/open_api_client/models/users_list_post_request_data_item_relationships_user_groups.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/users_list_post_request_data_item_relationships_user_groups_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/users_list_post_request_data_item_relationships_user_groups_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/users_list_post_request_data_item_relationships_user_groups_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/users_list_post_request_data_item_relationships_user_groups_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/users_list_post_request_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/users_list_post_request_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/users_list_post_response.py
+++ b/polarion_rest_api_client/open_api_client/models/users_list_post_response.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/users_list_post_response_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/users_list_post_response_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/users_list_post_response_data_item_links.py
+++ b/polarion_rest_api_client/open_api_client/models/users_list_post_response_data_item_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/users_list_post_response_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/users_list_post_response_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/users_single_get_response.py
+++ b/polarion_rest_api_client/open_api_client/models/users_single_get_response.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/users_single_get_response_data.py
+++ b/polarion_rest_api_client/open_api_client/models/users_single_get_response_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/users_single_get_response_data_attributes.py
+++ b/polarion_rest_api_client/open_api_client/models/users_single_get_response_data_attributes.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/users_single_get_response_data_attributes_description.py
+++ b/polarion_rest_api_client/open_api_client/models/users_single_get_response_data_attributes_description.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/users_single_get_response_data_attributes_description_type.py
+++ b/polarion_rest_api_client/open_api_client/models/users_single_get_response_data_attributes_description_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/users_single_get_response_data_links.py
+++ b/polarion_rest_api_client/open_api_client/models/users_single_get_response_data_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/users_single_get_response_data_meta.py
+++ b/polarion_rest_api_client/open_api_client/models/users_single_get_response_data_meta.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/users_single_get_response_data_meta_errors_item.py
+++ b/polarion_rest_api_client/open_api_client/models/users_single_get_response_data_meta_errors_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/users_single_get_response_data_meta_errors_item_source.py
+++ b/polarion_rest_api_client/open_api_client/models/users_single_get_response_data_meta_errors_item_source.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/users_single_get_response_data_relationships.py
+++ b/polarion_rest_api_client/open_api_client/models/users_single_get_response_data_relationships.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/users_single_get_response_data_relationships_global_roles.py
+++ b/polarion_rest_api_client/open_api_client/models/users_single_get_response_data_relationships_global_roles.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/users_single_get_response_data_relationships_global_roles_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/users_single_get_response_data_relationships_global_roles_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/users_single_get_response_data_relationships_global_roles_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/users_single_get_response_data_relationships_global_roles_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/users_single_get_response_data_relationships_global_roles_meta.py
+++ b/polarion_rest_api_client/open_api_client/models/users_single_get_response_data_relationships_global_roles_meta.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/users_single_get_response_data_relationships_project_roles.py
+++ b/polarion_rest_api_client/open_api_client/models/users_single_get_response_data_relationships_project_roles.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/users_single_get_response_data_relationships_project_roles_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/users_single_get_response_data_relationships_project_roles_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/users_single_get_response_data_relationships_project_roles_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/users_single_get_response_data_relationships_project_roles_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/users_single_get_response_data_relationships_project_roles_meta.py
+++ b/polarion_rest_api_client/open_api_client/models/users_single_get_response_data_relationships_project_roles_meta.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/users_single_get_response_data_relationships_user_groups.py
+++ b/polarion_rest_api_client/open_api_client/models/users_single_get_response_data_relationships_user_groups.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/users_single_get_response_data_relationships_user_groups_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/users_single_get_response_data_relationships_user_groups_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/users_single_get_response_data_relationships_user_groups_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/users_single_get_response_data_relationships_user_groups_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/users_single_get_response_data_relationships_user_groups_meta.py
+++ b/polarion_rest_api_client/open_api_client/models/users_single_get_response_data_relationships_user_groups_meta.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/users_single_get_response_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/users_single_get_response_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/users_single_get_response_included_item.py
+++ b/polarion_rest_api_client/open_api_client/models/users_single_get_response_included_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar

--- a/polarion_rest_api_client/open_api_client/models/users_single_get_response_links.py
+++ b/polarion_rest_api_client/open_api_client/models/users_single_get_response_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/users_single_patch_request.py
+++ b/polarion_rest_api_client/open_api_client/models/users_single_patch_request.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/users_single_patch_request_data.py
+++ b/polarion_rest_api_client/open_api_client/models/users_single_patch_request_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/users_single_patch_request_data_attributes.py
+++ b/polarion_rest_api_client/open_api_client/models/users_single_patch_request_data_attributes.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/users_single_patch_request_data_attributes_description.py
+++ b/polarion_rest_api_client/open_api_client/models/users_single_patch_request_data_attributes_description.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/users_single_patch_request_data_attributes_description_type.py
+++ b/polarion_rest_api_client/open_api_client/models/users_single_patch_request_data_attributes_description_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/users_single_patch_request_data_relationships.py
+++ b/polarion_rest_api_client/open_api_client/models/users_single_patch_request_data_relationships.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/users_single_patch_request_data_relationships_global_roles.py
+++ b/polarion_rest_api_client/open_api_client/models/users_single_patch_request_data_relationships_global_roles.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/users_single_patch_request_data_relationships_global_roles_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/users_single_patch_request_data_relationships_global_roles_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/users_single_patch_request_data_relationships_global_roles_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/users_single_patch_request_data_relationships_global_roles_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/users_single_patch_request_data_relationships_project_roles.py
+++ b/polarion_rest_api_client/open_api_client/models/users_single_patch_request_data_relationships_project_roles.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/users_single_patch_request_data_relationships_project_roles_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/users_single_patch_request_data_relationships_project_roles_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/users_single_patch_request_data_relationships_project_roles_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/users_single_patch_request_data_relationships_project_roles_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/users_single_patch_request_data_relationships_user_groups.py
+++ b/polarion_rest_api_client/open_api_client/models/users_single_patch_request_data_relationships_user_groups.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/users_single_patch_request_data_relationships_user_groups_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/users_single_patch_request_data_relationships_user_groups_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/users_single_patch_request_data_relationships_user_groups_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/users_single_patch_request_data_relationships_user_groups_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/users_single_patch_request_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/users_single_patch_request_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/workitem_attachments_list_get_response.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_attachments_list_get_response.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_attachments_list_get_response_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_attachments_list_get_response_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_attachments_list_get_response_data_item_attributes.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_attachments_list_get_response_data_item_attributes.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 import datetime

--- a/polarion_rest_api_client/open_api_client/models/workitem_attachments_list_get_response_data_item_links.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_attachments_list_get_response_data_item_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_attachments_list_get_response_data_item_meta.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_attachments_list_get_response_data_item_meta.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_attachments_list_get_response_data_item_meta_errors_item.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_attachments_list_get_response_data_item_meta_errors_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_attachments_list_get_response_data_item_meta_errors_item_source.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_attachments_list_get_response_data_item_meta_errors_item_source.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_attachments_list_get_response_data_item_relationships.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_attachments_list_get_response_data_item_relationships.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_attachments_list_get_response_data_item_relationships_author.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_attachments_list_get_response_data_item_relationships_author.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_attachments_list_get_response_data_item_relationships_author_data.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_attachments_list_get_response_data_item_relationships_author_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_attachments_list_get_response_data_item_relationships_author_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_attachments_list_get_response_data_item_relationships_author_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/workitem_attachments_list_get_response_data_item_relationships_project.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_attachments_list_get_response_data_item_relationships_project.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_attachments_list_get_response_data_item_relationships_project_data.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_attachments_list_get_response_data_item_relationships_project_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_attachments_list_get_response_data_item_relationships_project_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_attachments_list_get_response_data_item_relationships_project_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/workitem_attachments_list_get_response_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_attachments_list_get_response_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/workitem_attachments_list_get_response_included_item.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_attachments_list_get_response_included_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar

--- a/polarion_rest_api_client/open_api_client/models/workitem_attachments_list_get_response_links.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_attachments_list_get_response_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_attachments_list_get_response_meta.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_attachments_list_get_response_meta.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_attachments_list_post_request.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_attachments_list_post_request.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_attachments_list_post_request_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_attachments_list_post_request_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_attachments_list_post_request_data_item_attributes.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_attachments_list_post_request_data_item_attributes.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_attachments_list_post_request_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_attachments_list_post_request_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/workitem_attachments_list_post_response.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_attachments_list_post_response.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_attachments_list_post_response_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_attachments_list_post_response_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_attachments_list_post_response_data_item_links.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_attachments_list_post_response_data_item_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_attachments_list_post_response_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_attachments_list_post_response_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/workitem_attachments_single_get_response.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_attachments_single_get_response.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_attachments_single_get_response_data.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_attachments_single_get_response_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_attachments_single_get_response_data_attributes.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_attachments_single_get_response_data_attributes.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 import datetime

--- a/polarion_rest_api_client/open_api_client/models/workitem_attachments_single_get_response_data_links.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_attachments_single_get_response_data_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_attachments_single_get_response_data_meta.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_attachments_single_get_response_data_meta.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_attachments_single_get_response_data_meta_errors_item.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_attachments_single_get_response_data_meta_errors_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_attachments_single_get_response_data_meta_errors_item_source.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_attachments_single_get_response_data_meta_errors_item_source.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_attachments_single_get_response_data_relationships.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_attachments_single_get_response_data_relationships.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_attachments_single_get_response_data_relationships_author.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_attachments_single_get_response_data_relationships_author.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_attachments_single_get_response_data_relationships_author_data.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_attachments_single_get_response_data_relationships_author_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_attachments_single_get_response_data_relationships_author_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_attachments_single_get_response_data_relationships_author_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/workitem_attachments_single_get_response_data_relationships_project.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_attachments_single_get_response_data_relationships_project.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_attachments_single_get_response_data_relationships_project_data.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_attachments_single_get_response_data_relationships_project_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_attachments_single_get_response_data_relationships_project_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_attachments_single_get_response_data_relationships_project_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/workitem_attachments_single_get_response_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_attachments_single_get_response_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/workitem_attachments_single_get_response_included_item.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_attachments_single_get_response_included_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar

--- a/polarion_rest_api_client/open_api_client/models/workitem_attachments_single_get_response_links.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_attachments_single_get_response_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_attachments_single_patch_request.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_attachments_single_patch_request.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_attachments_single_patch_request_data.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_attachments_single_patch_request_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_attachments_single_patch_request_data_attributes.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_attachments_single_patch_request_data_attributes.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_attachments_single_patch_request_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_attachments_single_patch_request_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_list_get_response.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_list_get_response.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_list_get_response_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_list_get_response_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_list_get_response_data_item_attributes.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_list_get_response_data_item_attributes.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 import datetime

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_list_get_response_data_item_attributes_text.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_list_get_response_data_item_attributes_text.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_list_get_response_data_item_attributes_text_type.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_list_get_response_data_item_attributes_text_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_list_get_response_data_item_links.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_list_get_response_data_item_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_list_get_response_data_item_meta.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_list_get_response_data_item_meta.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_list_get_response_data_item_meta_errors_item.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_list_get_response_data_item_meta_errors_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_list_get_response_data_item_meta_errors_item_source.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_list_get_response_data_item_meta_errors_item_source.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_list_get_response_data_item_relationships.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_list_get_response_data_item_relationships.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_list_get_response_data_item_relationships_author.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_list_get_response_data_item_relationships_author.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_list_get_response_data_item_relationships_author_data.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_list_get_response_data_item_relationships_author_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_list_get_response_data_item_relationships_author_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_list_get_response_data_item_relationships_author_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_list_get_response_data_item_relationships_child_comments.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_list_get_response_data_item_relationships_child_comments.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_list_get_response_data_item_relationships_child_comments_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_list_get_response_data_item_relationships_child_comments_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_list_get_response_data_item_relationships_child_comments_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_list_get_response_data_item_relationships_child_comments_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_list_get_response_data_item_relationships_child_comments_meta.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_list_get_response_data_item_relationships_child_comments_meta.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_list_get_response_data_item_relationships_parent_comment.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_list_get_response_data_item_relationships_parent_comment.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_list_get_response_data_item_relationships_parent_comment_data.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_list_get_response_data_item_relationships_parent_comment_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_list_get_response_data_item_relationships_parent_comment_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_list_get_response_data_item_relationships_parent_comment_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_list_get_response_data_item_relationships_project.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_list_get_response_data_item_relationships_project.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_list_get_response_data_item_relationships_project_data.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_list_get_response_data_item_relationships_project_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_list_get_response_data_item_relationships_project_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_list_get_response_data_item_relationships_project_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_list_get_response_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_list_get_response_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_list_get_response_included_item.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_list_get_response_included_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_list_get_response_links.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_list_get_response_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_list_get_response_meta.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_list_get_response_meta.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_list_post_request.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_list_post_request.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_list_post_request_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_list_post_request_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_list_post_request_data_item_attributes.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_list_post_request_data_item_attributes.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_list_post_request_data_item_attributes_text.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_list_post_request_data_item_attributes_text.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_list_post_request_data_item_attributes_text_type.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_list_post_request_data_item_attributes_text_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_list_post_request_data_item_relationships.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_list_post_request_data_item_relationships.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_list_post_request_data_item_relationships_author.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_list_post_request_data_item_relationships_author.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_list_post_request_data_item_relationships_author_data.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_list_post_request_data_item_relationships_author_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_list_post_request_data_item_relationships_author_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_list_post_request_data_item_relationships_author_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_list_post_request_data_item_relationships_parent_comment.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_list_post_request_data_item_relationships_parent_comment.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_list_post_request_data_item_relationships_parent_comment_data.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_list_post_request_data_item_relationships_parent_comment_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_list_post_request_data_item_relationships_parent_comment_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_list_post_request_data_item_relationships_parent_comment_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_list_post_request_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_list_post_request_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_list_post_response.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_list_post_response.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_list_post_response_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_list_post_response_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_list_post_response_data_item_links.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_list_post_response_data_item_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_list_post_response_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_list_post_response_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_single_get_response.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_single_get_response.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_single_get_response_data.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_single_get_response_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_single_get_response_data_attributes.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_single_get_response_data_attributes.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 import datetime

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_single_get_response_data_attributes_text.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_single_get_response_data_attributes_text.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_single_get_response_data_attributes_text_type.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_single_get_response_data_attributes_text_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_single_get_response_data_links.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_single_get_response_data_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_single_get_response_data_meta.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_single_get_response_data_meta.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_single_get_response_data_meta_errors_item.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_single_get_response_data_meta_errors_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_single_get_response_data_meta_errors_item_source.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_single_get_response_data_meta_errors_item_source.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_single_get_response_data_relationships.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_single_get_response_data_relationships.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_single_get_response_data_relationships_author.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_single_get_response_data_relationships_author.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_single_get_response_data_relationships_author_data.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_single_get_response_data_relationships_author_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_single_get_response_data_relationships_author_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_single_get_response_data_relationships_author_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_single_get_response_data_relationships_child_comments.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_single_get_response_data_relationships_child_comments.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_single_get_response_data_relationships_child_comments_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_single_get_response_data_relationships_child_comments_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_single_get_response_data_relationships_child_comments_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_single_get_response_data_relationships_child_comments_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_single_get_response_data_relationships_child_comments_meta.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_single_get_response_data_relationships_child_comments_meta.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_single_get_response_data_relationships_parent_comment.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_single_get_response_data_relationships_parent_comment.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_single_get_response_data_relationships_parent_comment_data.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_single_get_response_data_relationships_parent_comment_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_single_get_response_data_relationships_parent_comment_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_single_get_response_data_relationships_parent_comment_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_single_get_response_data_relationships_project.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_single_get_response_data_relationships_project.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_single_get_response_data_relationships_project_data.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_single_get_response_data_relationships_project_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_single_get_response_data_relationships_project_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_single_get_response_data_relationships_project_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_single_get_response_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_single_get_response_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_single_get_response_included_item.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_single_get_response_included_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_single_get_response_links.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_single_get_response_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_single_patch_request.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_single_patch_request.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_single_patch_request_data.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_single_patch_request_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_single_patch_request_data_attributes.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_single_patch_request_data_attributes.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitem_comments_single_patch_request_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/workitem_comments_single_patch_request_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_delete_request.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_delete_request.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_delete_request_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_delete_request_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_delete_request_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_delete_request_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_get_response.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_get_response.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_attributes.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_attributes.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 import datetime

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_attributes_description.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_attributes_description.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_attributes_description_type.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_attributes_description_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_attributes_hyperlinks_item.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_attributes_hyperlinks_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_links.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_meta.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_meta.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_meta_errors_item.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_meta_errors_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_meta_errors_item_source.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_meta_errors_item_source.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_assignee.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_assignee.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_assignee_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_assignee_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_assignee_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_assignee_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_assignee_meta.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_assignee_meta.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_attachments.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_attachments.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_attachments_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_attachments_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_attachments_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_attachments_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_attachments_links.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_attachments_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_attachments_meta.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_attachments_meta.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_author.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_author.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_author_data.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_author_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_author_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_author_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_categories.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_categories.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_categories_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_categories_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_categories_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_categories_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_categories_meta.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_categories_meta.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_comments.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_comments.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_comments_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_comments_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_comments_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_comments_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_comments_links.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_comments_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_comments_meta.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_comments_meta.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_linked_work_items.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_linked_work_items.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_linked_work_items_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_linked_work_items_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_linked_work_items_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_linked_work_items_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_linked_work_items_links.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_linked_work_items_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_linked_work_items_meta.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_linked_work_items_meta.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_module.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_module.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_module_data.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_module_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_module_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_module_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_planned_in.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_planned_in.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_planned_in_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_planned_in_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_planned_in_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_planned_in_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_planned_in_meta.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_planned_in_meta.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_project.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_project.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_project_data.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_project_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_project_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_project_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_watches.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_watches.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_watches_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_watches_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_watches_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_watches_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_watches_meta.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_relationships_watches_meta.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_included_item.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_included_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_links.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_meta.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_get_response_meta.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_post_request.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_post_request.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_post_request_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_post_request_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_post_request_data_item_attributes.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_post_request_data_item_attributes.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 import datetime

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_post_request_data_item_attributes_description.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_post_request_data_item_attributes_description.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_post_request_data_item_attributes_description_type.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_post_request_data_item_attributes_description_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_post_request_data_item_attributes_hyperlinks_item.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_post_request_data_item_attributes_hyperlinks_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_post_request_data_item_relationships.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_post_request_data_item_relationships.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_post_request_data_item_relationships_assignee.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_post_request_data_item_relationships_assignee.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_post_request_data_item_relationships_assignee_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_post_request_data_item_relationships_assignee_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_post_request_data_item_relationships_assignee_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_post_request_data_item_relationships_assignee_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_post_request_data_item_relationships_author.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_post_request_data_item_relationships_author.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_post_request_data_item_relationships_author_data.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_post_request_data_item_relationships_author_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_post_request_data_item_relationships_author_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_post_request_data_item_relationships_author_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_post_request_data_item_relationships_categories.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_post_request_data_item_relationships_categories.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_post_request_data_item_relationships_categories_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_post_request_data_item_relationships_categories_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_post_request_data_item_relationships_categories_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_post_request_data_item_relationships_categories_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_post_request_data_item_relationships_module.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_post_request_data_item_relationships_module.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_post_request_data_item_relationships_module_data.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_post_request_data_item_relationships_module_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_post_request_data_item_relationships_module_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_post_request_data_item_relationships_module_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_post_request_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_post_request_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_post_response.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_post_response.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_post_response_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_post_response_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_post_response_data_item_links.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_post_response_data_item_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_list_post_response_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_list_post_response_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_get_response.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_get_response.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_attributes.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_attributes.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 import datetime

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_attributes_description.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_attributes_description.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_attributes_description_type.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_attributes_description_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_attributes_hyperlinks_item.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_attributes_hyperlinks_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_links.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_meta.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_meta.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_meta_errors_item.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_meta_errors_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_meta_errors_item_source.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_meta_errors_item_source.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_assignee.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_assignee.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_assignee_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_assignee_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_assignee_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_assignee_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_assignee_meta.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_assignee_meta.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_attachments.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_attachments.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_attachments_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_attachments_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_attachments_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_attachments_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_attachments_links.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_attachments_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_attachments_meta.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_attachments_meta.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_author.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_author.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_author_data.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_author_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_author_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_author_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_categories.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_categories.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_categories_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_categories_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_categories_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_categories_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_categories_meta.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_categories_meta.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_comments.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_comments.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_comments_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_comments_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_comments_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_comments_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_comments_links.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_comments_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_comments_meta.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_comments_meta.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_linked_work_items.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_linked_work_items.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_linked_work_items_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_linked_work_items_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_linked_work_items_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_linked_work_items_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_linked_work_items_links.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_linked_work_items_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_linked_work_items_meta.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_linked_work_items_meta.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_module.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_module.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_module_data.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_module_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_module_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_module_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_planned_in.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_planned_in.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_planned_in_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_planned_in_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_planned_in_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_planned_in_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_planned_in_meta.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_planned_in_meta.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_project.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_project.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_project_data.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_project_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_project_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_project_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_watches.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_watches.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_watches_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_watches_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_watches_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_watches_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_watches_meta.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_watches_meta.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_included_item.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_included_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_links.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_links.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_patch_request.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_patch_request.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_patch_request_data.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_patch_request_data.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_patch_request_data_attributes.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_patch_request_data_attributes.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 import datetime

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_patch_request_data_attributes_description.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_patch_request_data_attributes_description.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_patch_request_data_attributes_description_type.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_patch_request_data_attributes_description_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_patch_request_data_attributes_hyperlinks_item.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_patch_request_data_attributes_hyperlinks_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_patch_request_data_relationships.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_patch_request_data_relationships.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_patch_request_data_relationships_assignee.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_patch_request_data_relationships_assignee.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_patch_request_data_relationships_assignee_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_patch_request_data_relationships_assignee_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_patch_request_data_relationships_assignee_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_patch_request_data_relationships_assignee_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_patch_request_data_relationships_categories.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_patch_request_data_relationships_categories.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_patch_request_data_relationships_categories_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_patch_request_data_relationships_categories_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_patch_request_data_relationships_categories_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_patch_request_data_relationships_categories_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_patch_request_data_relationships_watches.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_patch_request_data_relationships_watches.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_patch_request_data_relationships_watches_data_item.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_patch_request_data_relationships_watches_data_item.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from typing import Any, Dict, List, Type, TypeVar, Union

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_patch_request_data_relationships_watches_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_patch_request_data_relationships_watches_data_item_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/models/workitems_single_patch_request_data_type.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_patch_request_data_type.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from enum import Enum

--- a/polarion_rest_api_client/open_api_client/types.py
+++ b/polarion_rest_api_client/open_api_client/types.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 """Contains some shared types for properties."""
 from http import HTTPStatus

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 [build-system]
@@ -14,7 +14,7 @@ readme = "README.md"
 requires-python = ">=3.10, <3.13"
 license = { text = "Apache-2.0" }
 authors = [
-  { name = "DB Netz AG" },
+  { name = "DB InfraGO AG" },
 ]
 keywords = []
 classifiers = [

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations

--- a/tests/data/expected_requests/delete_work_item.json.license
+++ b/tests/data/expected_requests/delete_work_item.json.license
@@ -1,2 +1,2 @@
-Copyright DB Netz AG and contributors
+Copyright DB InfraGO AG and contributors
 SPDX-License-Identifier: Apache-2.0

--- a/tests/data/expected_requests/delete_work_item_link.json.license
+++ b/tests/data/expected_requests/delete_work_item_link.json.license
@@ -1,2 +1,2 @@
-Copyright DB Netz AG and contributors
+Copyright DB InfraGO AG and contributors
 SPDX-License-Identifier: Apache-2.0

--- a/tests/data/expected_requests/delete_work_item_link_2.json.license
+++ b/tests/data/expected_requests/delete_work_item_link_2.json.license
@@ -1,2 +1,2 @@
-Copyright DB Netz AG and contributors
+Copyright DB InfraGO AG and contributors
 SPDX-License-Identifier: Apache-2.0

--- a/tests/data/expected_requests/delete_work_item_links.json.license
+++ b/tests/data/expected_requests/delete_work_item_links.json.license
@@ -1,2 +1,2 @@
-Copyright DB Netz AG and contributors
+Copyright DB InfraGO AG and contributors
 SPDX-License-Identifier: Apache-2.0

--- a/tests/data/expected_requests/delete_work_items.json.license
+++ b/tests/data/expected_requests/delete_work_items.json.license
@@ -1,2 +1,2 @@
-Copyright DB Netz AG and contributors
+Copyright DB InfraGO AG and contributors
 SPDX-License-Identifier: Apache-2.0

--- a/tests/data/expected_requests/patch_work_item_completely.json.license
+++ b/tests/data/expected_requests/patch_work_item_completely.json.license
@@ -1,2 +1,2 @@
-Copyright DB Netz AG and contributors
+Copyright DB InfraGO AG and contributors
 SPDX-License-Identifier: Apache-2.0

--- a/tests/data/expected_requests/patch_work_item_description.json.license
+++ b/tests/data/expected_requests/patch_work_item_description.json.license
@@ -1,2 +1,2 @@
-Copyright DB Netz AG and contributors
+Copyright DB InfraGO AG and contributors
 SPDX-License-Identifier: Apache-2.0

--- a/tests/data/expected_requests/patch_work_item_status.json.license
+++ b/tests/data/expected_requests/patch_work_item_status.json.license
@@ -1,2 +1,2 @@
-Copyright DB Netz AG and contributors
+Copyright DB InfraGO AG and contributors
 SPDX-License-Identifier: Apache-2.0

--- a/tests/data/expected_requests/patch_work_item_status_deleted.json.license
+++ b/tests/data/expected_requests/patch_work_item_status_deleted.json.license
@@ -1,2 +1,2 @@
-Copyright DB Netz AG and contributors
+Copyright DB InfraGO AG and contributors
 SPDX-License-Identifier: Apache-2.0

--- a/tests/data/expected_requests/patch_work_item_title.json.license
+++ b/tests/data/expected_requests/patch_work_item_title.json.license
@@ -1,2 +1,2 @@
-Copyright DB Netz AG and contributors
+Copyright DB InfraGO AG and contributors
 SPDX-License-Identifier: Apache-2.0

--- a/tests/data/expected_requests/post_work_item_link.json.license
+++ b/tests/data/expected_requests/post_work_item_link.json.license
@@ -1,2 +1,2 @@
-Copyright DB Netz AG and contributors
+Copyright DB InfraGO AG and contributors
 SPDX-License-Identifier: Apache-2.0

--- a/tests/data/expected_requests/post_work_item_links.json.license
+++ b/tests/data/expected_requests/post_work_item_links.json.license
@@ -1,2 +1,2 @@
-Copyright DB Netz AG and contributors
+Copyright DB InfraGO AG and contributors
 SPDX-License-Identifier: Apache-2.0

--- a/tests/data/expected_requests/post_workitem.json.license
+++ b/tests/data/expected_requests/post_workitem.json.license
@@ -1,2 +1,2 @@
-Copyright DB Netz AG and contributors
+Copyright DB InfraGO AG and contributors
 SPDX-License-Identifier: Apache-2.0

--- a/tests/data/expected_requests/post_workitems.json.license
+++ b/tests/data/expected_requests/post_workitems.json.license
@@ -1,2 +1,2 @@
-Copyright DB Netz AG and contributors
+Copyright DB InfraGO AG and contributors
 SPDX-License-Identifier: Apache-2.0

--- a/tests/data/mock_api_responses/created_work_item_attachment.json.license
+++ b/tests/data/mock_api_responses/created_work_item_attachment.json.license
@@ -1,2 +1,2 @@
-Copyright DB Netz AG and contributors
+Copyright DB InfraGO AG and contributors
 SPDX-License-Identifier: Apache-2.0

--- a/tests/data/mock_api_responses/created_work_item_attachments.json.license
+++ b/tests/data/mock_api_responses/created_work_item_attachments.json.license
@@ -1,2 +1,2 @@
-Copyright DB Netz AG and contributors
+Copyright DB InfraGO AG and contributors
 SPDX-License-Identifier: Apache-2.0

--- a/tests/data/mock_api_responses/created_work_item_links.json.license
+++ b/tests/data/mock_api_responses/created_work_item_links.json.license
@@ -1,2 +1,2 @@
-Copyright DB Netz AG and contributors
+Copyright DB InfraGO AG and contributors
 SPDX-License-Identifier: Apache-2.0

--- a/tests/data/mock_api_responses/created_work_items.json.license
+++ b/tests/data/mock_api_responses/created_work_items.json.license
@@ -1,2 +1,2 @@
-Copyright DB Netz AG and contributors
+Copyright DB InfraGO AG and contributors
 SPDX-License-Identifier: Apache-2.0

--- a/tests/data/mock_api_responses/error.json.license
+++ b/tests/data/mock_api_responses/error.json.license
@@ -1,2 +1,2 @@
-Copyright DB Netz AG and contributors
+Copyright DB InfraGO AG and contributors
 SPDX-License-Identifier: Apache-2.0

--- a/tests/data/mock_api_responses/get_linked_work_items_next_page.json.license
+++ b/tests/data/mock_api_responses/get_linked_work_items_next_page.json.license
@@ -1,2 +1,2 @@
-Copyright DB Netz AG and contributors
+Copyright DB InfraGO AG and contributors
 SPDX-License-Identifier: Apache-2.0

--- a/tests/data/mock_api_responses/get_linked_work_items_no_next_page.json.license
+++ b/tests/data/mock_api_responses/get_linked_work_items_no_next_page.json.license
@@ -1,2 +1,2 @@
-Copyright DB Netz AG and contributors
+Copyright DB InfraGO AG and contributors
 SPDX-License-Identifier: Apache-2.0

--- a/tests/data/mock_api_responses/get_work_item_attachments_next_page.json.license
+++ b/tests/data/mock_api_responses/get_work_item_attachments_next_page.json.license
@@ -1,2 +1,2 @@
-Copyright DB Netz AG and contributors
+Copyright DB InfraGO AG and contributors
 SPDX-License-Identifier: Apache-2.0

--- a/tests/data/mock_api_responses/get_work_item_attachments_no_next_page.json.license
+++ b/tests/data/mock_api_responses/get_work_item_attachments_no_next_page.json.license
@@ -1,2 +1,2 @@
-Copyright DB Netz AG and contributors
+Copyright DB InfraGO AG and contributors
 SPDX-License-Identifier: Apache-2.0

--- a/tests/data/mock_api_responses/project.json.license
+++ b/tests/data/mock_api_responses/project.json.license
@@ -1,2 +1,2 @@
-Copyright DB Netz AG and contributors
+Copyright DB InfraGO AG and contributors
 SPDX-License-Identifier: Apache-2.0

--- a/tests/data/mock_api_responses/workitems_next_page.json.license
+++ b/tests/data/mock_api_responses/workitems_next_page.json.license
@@ -1,2 +1,2 @@
-Copyright DB Netz AG and contributors
+Copyright DB InfraGO AG and contributors
 SPDX-License-Identifier: Apache-2.0

--- a/tests/data/mock_api_responses/workitems_next_page_error.json.license
+++ b/tests/data/mock_api_responses/workitems_next_page_error.json.license
@@ -1,2 +1,2 @@
-Copyright DB Netz AG and contributors
+Copyright DB InfraGO AG and contributors
 SPDX-License-Identifier: Apache-2.0

--- a/tests/data/mock_api_responses/workitems_no_next_page.json.license
+++ b/tests/data/mock_api_responses/workitems_no_next_page.json.license
@@ -1,2 +1,2 @@
-Copyright DB Netz AG and contributors
+Copyright DB InfraGO AG and contributors
 SPDX-License-Identifier: Apache-2.0

--- a/tests/test_client_general.py
+++ b/tests/test_client_general.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 from __future__ import annotations
 

--- a/tests/test_client_workitemattachments.py
+++ b/tests/test_client_workitemattachments.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations

--- a/tests/test_client_workitemlinks.py
+++ b/tests/test_client_workitemlinks.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations

--- a/tests/test_client_workitems.py
+++ b/tests/test_client_workitems.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations

--- a/tests/test_client_workitems_custom.py
+++ b/tests/test_client_workitems_custom.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations


### PR DESCRIPTION
`DB Netz AG` > `DB InfraGo AG`