### PR TITLE
fix(data-models): Remove post init checksum setting from `BaseItem`

### DIFF
--- a/polarion_rest_api_client/data_models.py
+++ b/polarion_rest_api_client/data_models.py
@@ -19,10 +19,6 @@ class BaseItem:
     status: str | None = None
     _checksum: str | None = dataclasses.field(init=False, default=None)
 
-    def __post_init__(self):
-        """Set initial checksum value."""
-        self._checksum = self.calculate_checksum()
-
     def __eq__(self, other: object) -> bool:
         """Compare only BaseItem attributes."""
         if not isinstance(other, BaseItem):

--- a/tests/test_client_documents.py
+++ b/tests/test_client_documents.py
@@ -1,4 +1,4 @@
-# Copyright DB Netz AG and contributors
+# Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations


### PR DESCRIPTION
Lead to a bug where the checksum was set on the abstract class and wouldn't ever be changed anymore.