### PR TITLE
fix: Set checksum from additional attributes

### DIFF
--- a/polarion_rest_api_client/data_models.py
+++ b/polarion_rest_api_client/data_models.py
@@ -87,6 +87,7 @@ class WorkItem(BaseItem):
         self.description_type = description_type
         self.description = description
         self.additional_attributes = (additional_attributes or {}) | kwargs
+        self._checksum = self.additional_attributes.pop("checksum", None)
         self.linked_work_items = linked_work_items or []
         self.attachments = attachments or []
 

--- a/tests/data/mock_api_responses/workitems_no_next_page.json
+++ b/tests/data/mock_api_responses/workitems_no_next_page.json
@@ -35,7 +35,8 @@
         "title": "Title",
         "type": "task",
         "updated": "1970-01-01T00:00:00Z",
-        "capella_uuid": "asdfgh"
+        "capella_uuid": "asdfgh",
+        "checksum": "123"
       },
       "relationships": {
         "assignee": {

--- a/tests/test_client_workitems.py
+++ b/tests/test_client_workitems.py
@@ -89,7 +89,7 @@ def test_get_all_work_items_single_page(
         "My text value",
         "task",
         "open",
-        {"capella_uuid": "asdfgh"},
+        {"capella_uuid": "asdfgh", "checksum": "123"},
         [
             polarion_api.WorkItemLink(
                 "MyWorkItemId2",
@@ -101,6 +101,8 @@ def test_get_all_work_items_single_page(
         ],
         [polarion_api.WorkItemAttachment("MyWorkItemId2", "MyAttachmentId")],
     )
+    assert "checksum" not in work_items[0].additional_attributes
+    assert work_items[0].get_current_checksum() == "123"
 
 
 def test_get_all_work_items_faulty_item(


### PR DESCRIPTION
In a previous PR we introduced a bug due to that the checksum wasn't picket from the additional attributes. This leads to an unstable checksum for work items as the new checksum included the previous one for the calculation. A test was adjusted to test the fix. Without the changes in the `data_models.py` the test fails now, but with the fix it passes