### PR TITLE
fix: Unnoticed `None` values in errors

### DIFF
--- a/polarion_rest_api_client/open_api_client/models/errors_errors_item.py
+++ b/polarion_rest_api_client/open_api_client/models/errors_errors_item.py
@@ -72,7 +72,7 @@ class ErrorsErrorsItem:
 
         _source = d.pop("source", UNSET)
         source: Union[Unset, ErrorsErrorsItemSource]
-        if isinstance(_source, Unset):
+        if isinstance(_source, (Unset, type(None))):
             source = UNSET
         else:
             source = ErrorsErrorsItemSource.from_dict(_source)

--- a/polarion_rest_api_client/open_api_client/models/errors_errors_item_source.py
+++ b/polarion_rest_api_client/open_api_client/models/errors_errors_item_source.py
@@ -67,7 +67,7 @@ class ErrorsErrorsItemSource:
 
         _resource = d.pop("resource", UNSET)
         resource: Union[Unset, ErrorsErrorsItemSourceResource]
-        if isinstance(_resource, Unset):
+        if isinstance(_resource, (Unset, type(None))):
             resource = UNSET
         else:
             resource = ErrorsErrorsItemSourceResource.from_dict(_resource)


### PR DESCRIPTION
When dealing with configuration errors on the Polarion project the API responds with None values. This isn't handled in these methods.