### PR TITLE
fix: `WorkitemsSingleGetResponseDataRelationshipsApprovalsDataItemType` missing option

### DIFF
--- a/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_approvals_data_item_type.py
+++ b/polarion_rest_api_client/open_api_client/models/workitems_single_get_response_data_relationships_approvals_data_item_type.py
@@ -7,6 +7,7 @@ from enum import Enum
 class WorkitemsSingleGetResponseDataRelationshipsApprovalsDataItemType(
     str, Enum
 ):
+    WORKITEM_APPROVALS = "workitem_approvals"
     WORKRECORDS = "workrecords"
 
     def __str__(self) -> str:


### PR DESCRIPTION
Somehow in relationships there can be workitem_approvals included. This is missing in the enum data type.