### PR TITLE
feat: use truststore to verify SSL certificates by default

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,11 +31,11 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/PyCQA/isort
-    rev: 5.13.2
+    rev: 6.0.1
     hooks:
       - id: isort
   - repo: https://github.com/PyCQA/docformatter
-    rev: v1.7.5
+    rev: eb1df347edd128b30cd3368dddc3aa65edcfac38 # Don't autoupdate until https://github.com/PyCQA/docformatter/issues/293 is fixed
     hooks:
       - id: docformatter
         additional_dependencies:

--- a/polarion_rest_api_client/client.py
+++ b/polarion_rest_api_client/client.py
@@ -1,9 +1,13 @@
 # Copyright DB InfraGO AG and contributors
 # SPDX-License-Identifier: Apache-2.0
 """The overall Polarion Client which handles the HTTP session, auth etc."""
+
 from __future__ import annotations
 
+import ssl
 import typing as t
+
+import truststore
 
 import polarion_rest_api_client.open_api_client as oa_client
 from polarion_rest_api_client import data_models as dm
@@ -110,10 +114,14 @@ class PolarionClient:
         batch_size: int = 100,
         page_size: int = 100,
         max_content_size: int = 2 * 1024**2,
+        verify_ssl: ssl.SSLContext | bool | None = None,
     ):
+        if verify_ssl is None:
+            verify_ssl = truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
         self.client = oa_client.AuthenticatedClient(
             polarion_api_endpoint,
             polarion_access_token,
+            verify_ssl=verify_ssl,
             httpx_args=httpx_args or {},
         )
         self.batch_size = batch_size

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
   "httpx>=0.20.0,<0.28.0",
   "attrs>=21.3.0",
   "python-dateutil>=2.8.0",
+  "truststore>=0.10.1",
 ]
 
 [project.urls]

--- a/tests/test_client_general.py
+++ b/tests/test_client_general.py
@@ -3,11 +3,58 @@
 from __future__ import annotations
 
 import json
+import ssl
+from unittest import mock
 
+import pytest
 import pytest_httpx
 
 import polarion_rest_api_client as polarion_api
 from tests.conftest import TEST_PROJECT_RESPONSE_JSON
+
+
+@mock.patch("httpx.Client")
+@pytest.mark.parametrize("verify_ssl", [False, True])
+def test_verify_ssl_boolean(mock_httpx_client, verify_ssl: bool | None):
+    polarion_client = polarion_api.PolarionClient(
+        polarion_api_endpoint="https://example.com",
+        polarion_access_token="fake_token",
+        verify_ssl=verify_ssl,
+    )
+
+    polarion_client.client.get_httpx_client()
+
+    _, kwargs = mock_httpx_client.call_args
+    assert kwargs["verify"] is verify_ssl
+
+
+@mock.patch("httpx.Client")
+def test_default_verify_ssl(mock_httpx_client):
+    polarion_client = polarion_api.PolarionClient(
+        polarion_api_endpoint="https://example.com",
+        polarion_access_token="fake_token",
+    )
+
+    polarion_client.client.get_httpx_client()
+
+    _, kwargs = mock_httpx_client.call_args
+    assert isinstance(kwargs["verify"], ssl.SSLContext)
+    assert kwargs["verify"].protocol == ssl.PROTOCOL_TLS_CLIENT
+
+
+@mock.patch("httpx.Client")
+def test_custom_ssl_context(mock_httpx_client):
+    custom_ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    polarion_client = polarion_api.PolarionClient(
+        polarion_api_endpoint="https://example.com",
+        polarion_access_token="fake_token",
+        verify_ssl=custom_ssl_context,
+    )
+
+    polarion_client.client.get_httpx_client()
+
+    _, kwargs = mock_httpx_client.call_args
+    assert kwargs["verify"] is custom_ssl_context
 
 
 def test_api_authentication(


### PR DESCRIPTION
This PR makes the `verify_ssl` parameter of the httpx client available. By default we now use [truststore](https://truststore.readthedocs.io/en/latest/) to provide an SSL context which is based on the native system certificate stores. 
The `verify_ssl` parameter can also be used to pass a custom SSL context or to disable certificate validation completely by setting the parameter to False. If one sets the parameter to True, httpx will use certifi to validate certificates as before. This combination of SSL context and boolean types is also the way it is implemented in httpx which is why we do it the same way here.