### PR TITLE
build: Change development status to valid value

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ authors = [
 ]
 keywords = []
 classifiers = [
-  "Development Status :: 5 - Production",
+  "Development Status :: 5 - Production/Stable",
   "Natural Language :: English",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3 :: Only",


### PR DESCRIPTION
`Development Status :: 5 - Production` is not a valid value: https://pypi.org/classifiers/
Due to the invalid value, the PyPi build fails. The last version (v1.4.2) wasn't deployed to PyPi.

Resolves #64