### PR TITLE
feat: Implement batched WorkItem updates via patch_work_items with size-aware batching

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ project_exists = project_client.exists() # Should be True
 work_items = project_client.work_items.get_all()
 ```
 During the initialization of the client you can define additional settings like the page size when getting items or the maximum content size when bulk creating new items.
+Async bulk operations (`async_create`, `async_update`, `async_delete`) execute their prepared batches concurrently.
+The number of requests that may run at the same time is limited via `max_async_in_flight_requests` on `PolarionClient`.
 In addition, you can define your own Work Item class with custom fields, which become available as attributes on object level instead of being part of the `additional_attributes` dictionary only.
 To use this feature, inherit from our Work Item class and pass your extended class when requesting Work Items:
 ```python

--- a/polarion_rest_api_client/client.py
+++ b/polarion_rest_api_client/client.py
@@ -137,6 +137,7 @@ class PolarionClient:
             verify_ssl=verify_ssl,
             httpx_args=httpx_args or {},
         )
+        self.max_async_in_flight_requests = max_async_in_flight_requests
         self.semaphore = asyncio.Semaphore(max_async_in_flight_requests)
         self.batch_size = batch_size
         self.page_size = page_size

--- a/polarion_rest_api_client/clients/base_classes.py
+++ b/polarion_rest_api_client/clients/base_classes.py
@@ -303,8 +303,12 @@ class CreateClient(BaseClient[T], abc.ABC):
         if not isinstance(items, list):
             items = [items]
 
-        for batch in self._split_into_create_batches(items):
-            await self._async_create(batch)
+        await asyncio.gather(
+            *[
+                self._async_create(batch)
+                for batch in self._split_into_create_batches(items)
+            ]
+        )
 
 
 class DeleteClient(BaseClient[T], abc.ABC):
@@ -341,8 +345,12 @@ class DeleteClient(BaseClient[T], abc.ABC):
         """Delete one or multiple items."""
         if not isinstance(items, list):
             items = [items]
-        for batch in self._split_into_delete_batches(items):
-            await self._async_delete(batch)
+        await asyncio.gather(
+            *[
+                self._async_delete(batch)
+                for batch in self._split_into_delete_batches(items)
+            ]
+        )
 
 
 class MultiGetClient(BaseClient[T], abc.ABC):

--- a/polarion_rest_api_client/clients/base_classes.py
+++ b/polarion_rest_api_client/clients/base_classes.py
@@ -452,8 +452,12 @@ class UpdateClient(BaseClient[T], abc.ABC):
         if not isinstance(items, list):
             items = [items]
 
-        for batch in self._split_into_update_batches(items):
-            await self._async_update(batch)
+        await asyncio.gather(
+            *[
+                self._async_update(batch)
+                for batch in self._split_into_update_batches(items)
+            ]
+        )
 
 
 class StatusItemClient(UpdateClient, DeleteClient, t.Generic[ST], abc.ABC):

--- a/polarion_rest_api_client/clients/base_classes.py
+++ b/polarion_rest_api_client/clients/base_classes.py
@@ -249,6 +249,32 @@ class BaseClient(t.Generic[T]):
         """
         yield items
 
+    async def _run_streaming_batch_calls(
+        self, calls: t.Iterable[t.Coroutine[t.Any, t.Any, None]]
+    ) -> None:
+        max_in_flight = max(1, self._client.max_async_in_flight_requests)
+        pending: set[asyncio.Task[None]] = set()
+
+        try:
+            for call in calls:
+                pending.add(asyncio.create_task(call))
+                if len(pending) >= max_in_flight:
+                    done, pending = await asyncio.wait(
+                        pending, return_when=asyncio.FIRST_COMPLETED
+                    )
+                    for task in done:
+                        task.result()
+
+            if pending:
+                done, _ = await asyncio.wait(pending)
+                for task in done:
+                    task.result()
+        except Exception:
+            for task in pending:
+                task.cancel()
+            await asyncio.gather(*pending, return_exceptions=True)
+            raise
+
 
 class SingleGetClient(BaseClient[T], abc.ABC):
     """A client for items of a project, which can be created."""
@@ -303,11 +329,9 @@ class CreateClient(BaseClient[T], abc.ABC):
         if not isinstance(items, list):
             items = [items]
 
-        await asyncio.gather(
-            *[
-                self._async_create(batch)
-                for batch in self._split_into_create_batches(items)
-            ]
+        await self._run_streaming_batch_calls(
+            self._async_create(batch)
+            for batch in self._split_into_create_batches(items)
         )
 
 
@@ -345,11 +369,9 @@ class DeleteClient(BaseClient[T], abc.ABC):
         """Delete one or multiple items."""
         if not isinstance(items, list):
             items = [items]
-        await asyncio.gather(
-            *[
-                self._async_delete(batch)
-                for batch in self._split_into_delete_batches(items)
-            ]
+        await self._run_streaming_batch_calls(
+            self._async_delete(batch)
+            for batch in self._split_into_delete_batches(items)
         )
 
 
@@ -460,11 +482,9 @@ class UpdateClient(BaseClient[T], abc.ABC):
         if not isinstance(items, list):
             items = [items]
 
-        await asyncio.gather(
-            *[
-                self._async_update(batch)
-                for batch in self._split_into_update_batches(items)
-            ]
+        await self._run_streaming_batch_calls(
+            self._async_update(batch)
+            for batch in self._split_into_update_batches(items)
         )
 
 

--- a/polarion_rest_api_client/clients/work_items.py
+++ b/polarion_rest_api_client/clients/work_items.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 """Implementation of a client providing work item specific functions."""
 
-import itertools
 import json
 import logging
 import typing as t
@@ -73,16 +72,25 @@ class WorkItems(
     def _update(self, to_update: list[dm.WorkItem]) -> None:
         raise NotImplementedError("We have a custom update instead.")
 
+    def _iter_update_groups(
+        self,
+        items: list[dm.WorkItem],
+    ) -> t.Iterable[tuple[str | None, list[dm.WorkItem]]]:
+        grouped: dict[str | None, list[dm.WorkItem]] = {}
+        for item in items:
+            grouped.setdefault(item.type, []).append(item)
+
+        yield from grouped.items()
+
     def _iter_update_batches(
-        self, items: list[dm.WorkItem]
+        self,
+        items: list[dm.WorkItem],
     ) -> t.Generator[
         tuple[api_models.WorkitemsListPatchRequest, str | None],
         None,
         None,
     ]:
-        for batch_type, to_update in itertools.groupby(
-            items, lambda item: item.type
-        ):
+        for batch_type, to_update in self._iter_update_groups(items):
             current_batch = api_models.WorkitemsListPatchRequest(data=[])
             content_size = min_wi_patch_request_size
 
@@ -172,7 +180,10 @@ class WorkItems(
         if current_batch.data:
             yield current_batch, items[batch_start_index:]
 
-    def update(self, items: dm.WorkItem | list[dm.WorkItem]) -> None:
+    def update(
+        self,
+        items: dm.WorkItem | list[dm.WorkItem],
+    ) -> None:
         """Update WorkItems and respect max body size and batch limits."""
         if not isinstance(items, list):
             items = [items]
@@ -184,7 +195,8 @@ class WorkItems(
         raise NotImplementedError("We have a custom async_update instead.")
 
     async def async_update(
-        self, items: dm.WorkItem | list[dm.WorkItem]
+        self,
+        items: dm.WorkItem | list[dm.WorkItem],
     ) -> None:
         """Update WorkItems and respect max body size and batch limits."""
         if not isinstance(items, list):

--- a/polarion_rest_api_client/clients/work_items.py
+++ b/polarion_rest_api_client/clients/work_items.py
@@ -103,7 +103,8 @@ class WorkItems(
 
                 assert isinstance(current_batch.data, list)
                 if (
-                    proj_content_size >= self._client.max_content_size
+                    current_batch.data
+                    and proj_content_size > self._client.max_content_size
                     or len(current_batch.data) >= self._client.batch_size
                 ):
                     yield current_batch, batch_type
@@ -151,7 +152,8 @@ class WorkItems(
 
             assert isinstance(current_batch.data, list)
             if (
-                proj_content_size >= self._client.max_content_size
+                current_batch.data
+                and proj_content_size > self._client.max_content_size
                 or len(current_batch.data) >= self._client.batch_size
             ):
                 yield current_batch, items[batch_start_index:batch_end_index]

--- a/polarion_rest_api_client/clients/work_items.py
+++ b/polarion_rest_api_client/clients/work_items.py
@@ -78,7 +78,7 @@ class WorkItems(
         item_builder: t.Callable[
             [dm.WorkItem], api_models.WorkitemsListPatchRequestDataItem
         ],
-    ) -> t.Generator[api_models.WorkitemsListPatchRequest, None, None]:
+    ) -> t.Iterator[api_models.WorkitemsListPatchRequest]:
         current_batch = api_models.WorkitemsListPatchRequest(data=[])
         content_size = min_wi_patch_request_size
 
@@ -118,7 +118,7 @@ class WorkItems(
     def _iter_update_batches(
         self,
         items: list[dm.WorkItem],
-    ) -> t.Generator[api_models.WorkitemsListPatchRequest, None, None]:
+    ) -> t.Iterator[api_models.WorkitemsListPatchRequest]:
         yield from self._iter_patch_batches(
             (item for item in items if self._has_content_to_patch(item)),
             self._build_work_item_list_patch_item,
@@ -127,11 +127,7 @@ class WorkItems(
     def _iter_type_change_batches(
         self,
         items: list[dm.WorkItem],
-    ) -> t.Generator[
-        tuple[api_models.WorkitemsListPatchRequest, str],
-        None,
-        None,
-    ]:
+    ) -> t.Iterator[tuple[api_models.WorkitemsListPatchRequest, str]]:
         grouped: dict[str, list[dm.WorkItem]] = {}
         for item in items:
             if item.type:
@@ -146,10 +142,8 @@ class WorkItems(
 
     def _iter_create_batches(
         self, items: list[dm.WorkItem]
-    ) -> t.Generator[
-        tuple[api_models.WorkitemsListPostRequest, list[dm.WorkItem]],
-        None,
-        None,
+    ) -> t.Iterator[
+        tuple[api_models.WorkitemsListPostRequest, list[dm.WorkItem]]
     ]:
         current_batch = api_models.WorkitemsListPostRequest(data=[])
         content_size = min_wi_request_size

--- a/polarion_rest_api_client/clients/work_items.py
+++ b/polarion_rest_api_client/clients/work_items.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Implementation of a client providing work item specific functions."""
 
+import asyncio
 import itertools
 import json
 import logging
@@ -134,6 +135,10 @@ class WorkItems(
         if not isinstance(items, list):
             items = [items]
 
+        patch_batches: list[
+            tuple[api_models.WorkitemsListPatchRequest, str | None]
+        ] = []
+
         for batch_type, to_update in itertools.groupby(
             items, lambda item: item.type
         ):
@@ -160,9 +165,7 @@ class WorkItems(
                     proj_content_size >= self._client.max_content_size
                     or len(current_batch.data) >= self._client.batch_size
                 ):
-                    await self._a_patch_work_item_batch(
-                        current_batch, batch_type
-                    )
+                    patch_batches.append((current_batch, batch_type))
 
                     current_batch = api_models.WorkitemsListPatchRequest(
                         data=[work_item_data]
@@ -178,7 +181,14 @@ class WorkItems(
                     content_size = proj_content_size
 
             if current_batch.data:
-                await self._a_patch_work_item_batch(current_batch, batch_type)
+                patch_batches.append((current_batch, batch_type))
+
+        await asyncio.gather(
+            *[
+                self._a_patch_work_item_batch(work_item_batch, batch_type)
+                for work_item_batch, batch_type in patch_batches
+            ]
+        )
 
     def _check_update_items(self, to_update: list[dm.WorkItem]) -> str | None:
         assert to_update, "Expected at least one item"
@@ -551,6 +561,9 @@ class WorkItems(
         """Create WorkItems and respect the max body size of the server."""
         if not isinstance(items, list):
             items = [items]
+        post_batches: list[
+            tuple[api_models.WorkitemsListPostRequest, list[dm.WorkItem]]
+        ] = []
         current_batch = api_models.WorkitemsListPostRequest(data=[])
         content_size = min_wi_request_size
         batch_start_index = 0
@@ -575,9 +588,11 @@ class WorkItems(
                 proj_content_size >= self._client.max_content_size
                 or len(current_batch.data) >= self._client.batch_size
             ):
-                await self._a_post_work_item_batch(
-                    current_batch,
-                    items[batch_start_index:batch_end_index],
+                post_batches.append(
+                    (
+                        current_batch,
+                        items[batch_start_index:batch_end_index],
+                    )
                 )
 
                 current_batch = api_models.WorkitemsListPostRequest(
@@ -591,10 +606,14 @@ class WorkItems(
                 content_size = proj_content_size
 
         if current_batch.data:
-            await self._a_post_work_item_batch(
-                current_batch,
-                items[batch_start_index:],
-            )
+            post_batches.append((current_batch, items[batch_start_index:]))
+
+        await asyncio.gather(
+            *[
+                self._a_post_work_item_batch(work_item_batch, work_item_objs)
+                for work_item_batch, work_item_objs in post_batches
+            ]
+        )
 
     def _delete(self, items: list[dm.WorkItem]) -> None:
         response = delete_work_items.sync_detailed(

--- a/polarion_rest_api_client/clients/work_items.py
+++ b/polarion_rest_api_client/clients/work_items.py
@@ -22,6 +22,7 @@ from . import base_classes as bc
 from . import test_steps, work_item_attachments, work_item_links
 
 WT = t.TypeVar("WT", bound=dm.WorkItem)
+BT = t.TypeVar("BT")
 logger = logging.getLogger(__name__)
 if t.TYPE_CHECKING:
     from polarion_rest_api_client import client as polarion_client
@@ -72,6 +73,26 @@ class WorkItems(
     def _update(self, to_update: list[dm.WorkItem]) -> None:
         raise NotImplementedError("We have a custom update instead.")
 
+    def _flush_or_append_batch_item(
+        self,
+        current_batch_data: list[BT],
+        item_data: BT,
+        *,
+        projected_content_size: int,
+        new_batch_content_size: int,
+    ) -> tuple[bool, int]:
+        if (
+            (
+                current_batch_data
+                and projected_content_size > self._client.max_content_size
+            )
+            or len(current_batch_data) >= self._client.batch_size
+        ):
+            return True, new_batch_content_size
+
+        current_batch_data.append(item_data)
+        return False, projected_content_size
+
     def _iter_update_groups(
         self,
         items: list[dm.WorkItem],
@@ -109,25 +130,21 @@ class WorkItems(
                         "A WorkItem is too large to update.", work_item
                     )
 
+                new_batch = api_models.WorkitemsListPatchRequest(
+                    data=[work_item_data]
+                )
                 assert isinstance(current_batch.data, list)
-                if (
-                    current_batch.data
-                    and proj_content_size > self._client.max_content_size
-                    or len(current_batch.data) >= self._client.batch_size
-                ):
+                should_flush, content_size = self._flush_or_append_batch_item(
+                    current_batch.data,
+                    work_item_data,
+                    projected_content_size=proj_content_size,
+                    new_batch_content_size=_get_json_content_size(
+                        new_batch.to_dict()
+                    ),
+                )
+                if should_flush:
                     yield current_batch, batch_type
-                    current_batch = api_models.WorkitemsListPatchRequest(
-                        data=[work_item_data]
-                    )
-                    content_size = _get_json_content_size(
-                        current_batch.to_dict()
-                    )
-                else:
-                    t.cast(
-                        list[api_models.WorkitemsListPatchRequestDataItem],
-                        current_batch.data,
-                    ).append(work_item_data)
-                    content_size = proj_content_size
+                    current_batch = new_batch
 
             if current_batch.data:
                 yield current_batch, batch_type
@@ -158,24 +175,20 @@ class WorkItems(
                     "A WorkItem is too large to create.", work_item
                 )
 
+            new_batch = api_models.WorkitemsListPostRequest(data=[work_item_data])
             assert isinstance(current_batch.data, list)
-            if (
-                current_batch.data
-                and proj_content_size > self._client.max_content_size
-                or len(current_batch.data) >= self._client.batch_size
-            ):
+            should_flush, content_size = self._flush_or_append_batch_item(
+                current_batch.data,
+                work_item_data,
+                projected_content_size=proj_content_size,
+                new_batch_content_size=_get_json_content_size(
+                    new_batch.to_dict()
+                ),
+            )
+            if should_flush:
                 yield current_batch, items[batch_start_index:batch_end_index]
-                current_batch = api_models.WorkitemsListPostRequest(
-                    data=[work_item_data]
-                )
-                content_size = _get_json_content_size(current_batch.to_dict())
+                current_batch = new_batch
                 batch_start_index = batch_end_index
-            else:
-                t.cast(
-                    list[api_models.WorkitemsListPostRequestDataItem],
-                    current_batch.data,
-                ).append(work_item_data)
-                content_size = proj_content_size
 
         if current_batch.data:
             yield current_batch, items[batch_start_index:]

--- a/polarion_rest_api_client/clients/work_items.py
+++ b/polarion_rest_api_client/clients/work_items.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Implementation of a client providing work item specific functions."""
 
+import itertools
 import json
 import logging
 import typing as t
@@ -14,7 +15,7 @@ from polarion_rest_api_client.open_api_client.api.work_items import (
     delete_work_items,
     get_work_item,
     get_work_items,
-    patch_work_item,
+    patch_work_items,
     post_work_items,
 )
 
@@ -34,6 +35,9 @@ def _get_json_content_size(data: dict) -> int:
 min_wi_request_size = _get_json_content_size(
     api_models.WorkitemsListPostRequest(data=[]).to_dict()
 )
+min_wi_patch_request_size = _get_json_content_size(
+    api_models.WorkitemsListPatchRequest(data=[]).to_dict()
+)
 
 
 class WorkItems(
@@ -45,7 +49,13 @@ class WorkItems(
 ):
     """A project specific client for work item operations."""
 
-    _update_batch_size = 1
+    _update_batch_size = 100
+    _retry_methods: t.ClassVar[set[str]] = {
+        "_post_work_item_batch",
+        "_a_post_work_item_batch",
+        "_patch_work_item_batch",
+        "_a_patch_work_item_batch",
+    }
 
     def __init__(
         self,
@@ -62,38 +72,129 @@ class WorkItems(
         self.item_cls = dm.WorkItem
 
     def _update(self, to_update: list[dm.WorkItem]) -> None:
-        item = self._check_update_item(to_update)
-        response = patch_work_item.sync_detailed(
-            self._project_id,
-            item.id,  # type: ignore
-            client=self._client.client,
-            change_type_to=item.type or oa_types.UNSET,
-            body=self._build_work_item_patch_request(item),
-        )
-        self._raise_on_error(response)
+        raise NotImplementedError("We have a custom update instead.")
+
+    def update(self, items: dm.WorkItem | list[dm.WorkItem]) -> None:
+        """Update WorkItems and respect max body size and batch limits."""
+        if not isinstance(items, list):
+            items = [items]
+
+        for batch_type, to_update in itertools.groupby(
+            items, lambda item: item.type
+        ):
+            current_batch = api_models.WorkitemsListPatchRequest(data=[])
+            content_size = min_wi_patch_request_size
+
+            for work_item in to_update:
+                assert work_item.id is not None
+                work_item_data = self._build_work_item_list_patch_item(
+                    work_item
+                )
+                proj_content_size, too_big = (
+                    self._calculate_patch_work_item_request_sizes(
+                        work_item_data, content_size
+                    )
+                )
+
+                if too_big:
+                    raise errors.PolarionWorkItemException(
+                        "A WorkItem is too large to update.", work_item
+                    )
+
+                assert isinstance(current_batch.data, list)
+                if (
+                    proj_content_size >= self._client.max_content_size
+                    or len(current_batch.data) >= self._client.batch_size
+                ):
+                    self._patch_work_item_batch(current_batch, batch_type)
+
+                    current_batch = api_models.WorkitemsListPatchRequest(
+                        data=[work_item_data]
+                    )
+                    content_size = _get_json_content_size(
+                        current_batch.to_dict()
+                    )
+                else:
+                    t.cast(
+                        list[api_models.WorkitemsListPatchRequestDataItem],
+                        current_batch.data,
+                    ).append(work_item_data)
+                    content_size = proj_content_size
+
+            if current_batch.data:
+                self._patch_work_item_batch(current_batch, batch_type)
 
     async def _async_update(self, to_update: list[dm.WorkItem]) -> None:
-        item = self._check_update_item(to_update)
-        response = await patch_work_item.asyncio_detailed(
-            self._project_id,
-            item.id,  # type: ignore
-            client=self._client.client,
-            change_type_to=item.type or oa_types.UNSET,
-            body=self._build_work_item_patch_request(item),
-        )
-        self._raise_on_error(response)
+        raise NotImplementedError("We have a custom update instead.")
 
-    def _check_update_item(self, to_update: list[dm.WorkItem]) -> dm.WorkItem:
-        assert len(to_update) == 1, "Expected only one item"
-        item = to_update[0]
-        assert item.id is not None
-        if item.type:
-            logger.warning(
-                "Attempting to change the type of Work Item %s to %s.",
-                item.id,
-                item.type,
-            )
-        return item
+    async def async_update(
+        self, items: dm.WorkItem | list[dm.WorkItem]
+    ) -> None:
+        """Update WorkItems and respect max body size and batch limits."""
+        if not isinstance(items, list):
+            items = [items]
+
+        for batch_type, to_update in itertools.groupby(
+            items, lambda item: item.type
+        ):
+            current_batch = api_models.WorkitemsListPatchRequest(data=[])
+            content_size = min_wi_patch_request_size
+
+            for work_item in to_update:
+                work_item_data = self._build_work_item_list_patch_item(
+                    work_item
+                )
+                proj_content_size, too_big = (
+                    self._calculate_patch_work_item_request_sizes(
+                        work_item_data, content_size
+                    )
+                )
+
+                if too_big:
+                    raise errors.PolarionWorkItemException(
+                        "A WorkItem is too large to update.", work_item
+                    )
+
+                assert isinstance(current_batch.data, list)
+                if (
+                    proj_content_size >= self._client.max_content_size
+                    or len(current_batch.data) >= self._client.batch_size
+                ):
+                    await self._a_patch_work_item_batch(
+                        current_batch, batch_type
+                    )
+
+                    current_batch = api_models.WorkitemsListPatchRequest(
+                        data=[work_item_data]
+                    )
+                    content_size = _get_json_content_size(
+                        current_batch.to_dict()
+                    )
+                else:
+                    t.cast(
+                        list[api_models.WorkitemsListPatchRequestDataItem],
+                        current_batch.data,
+                    ).append(work_item_data)
+                    content_size = proj_content_size
+
+            if current_batch.data:
+                await self._a_patch_work_item_batch(current_batch, batch_type)
+
+    def _check_update_items(self, to_update: list[dm.WorkItem]) -> str | None:
+        assert to_update, "Expected at least one item"
+
+        batch_type = to_update[0].type
+        for item in to_update:
+            assert item.id is not None
+            assert item.type == batch_type
+            if item.type:
+                logger.warning(
+                    "Attempting to change the type of Work Item %s to %s.",
+                    item.id,
+                    item.type,
+                )
+
+        return batch_type
 
     @t.overload  # type: ignore[override]
     def get_multi(
@@ -420,8 +521,7 @@ class WorkItems(
                 proj_content_size >= self._client.max_content_size
                 or len(current_batch.data) >= self._client.batch_size
             ):
-                self._retry_on_error(
-                    self._post_work_item_batch,
+                self._post_work_item_batch(
                     current_batch,
                     items[batch_start_index:batch_end_index],
                 )
@@ -437,8 +537,7 @@ class WorkItems(
                 content_size = proj_content_size
 
         if current_batch.data:
-            self._retry_on_error(
-                self._post_work_item_batch,
+            self._post_work_item_batch(
                 current_batch,
                 items[batch_start_index:],
             )
@@ -476,8 +575,7 @@ class WorkItems(
                 proj_content_size >= self._client.max_content_size
                 or len(current_batch.data) >= self._client.batch_size
             ):
-                await self._retry_on_error(
-                    self._a_post_work_item_batch,
+                await self._a_post_work_item_batch(
                     current_batch,
                     items[batch_start_index:batch_end_index],
                 )
@@ -493,8 +591,7 @@ class WorkItems(
                 content_size = proj_content_size
 
         if current_batch.data:
-            await self._retry_on_error(
-                self._a_post_work_item_batch,
+            await self._a_post_work_item_batch(
                 current_batch,
                 items[batch_start_index:],
             )
@@ -624,6 +721,99 @@ class WorkItems(
                 attributes=attrs,
             )
         )
+
+    def _build_work_item_list_patch_item(
+        self, work_item: dm.WorkItem
+    ) -> api_models.WorkitemsListPatchRequestDataItem:
+        if work_item.type:
+            logger.warning(
+                "Attempting to change the type of Work Item %s to %s.",
+                work_item.id,
+                work_item.type,
+            )
+
+        attrs = api_models.WorkitemsListPatchRequestDataItemAttributes()
+
+        if work_item.home_document:
+            logger.warning(
+                "Changing the work items home document is not supported."
+            )
+
+        if work_item.title is not None:
+            attrs.title = work_item.title
+
+        if work_item.description is not None:
+            attrs.description = api_models.WorkitemsListPatchRequestDataItemAttributesDescription(  # pylint: disable=line-too-long
+                type_=api_models.WorkitemsListPatchRequestDataItemAttributesDescriptionType(  # pylint: disable=line-too-long
+                    work_item.description.type
+                ),
+                value=work_item.description.value or "",
+            )
+
+        if work_item.status is not None:
+            attrs.status = work_item.status
+
+        if work_item.hyperlinks is not None:
+            attrs.hyperlinks = [
+                api_models.WorkitemsListPatchRequestDataItemAttributesHyperlinksItem(
+                    role=hyperlink.role or oa_types.UNSET,
+                    title=hyperlink.title or oa_types.UNSET,
+                    uri=hyperlink.uri or oa_types.UNSET,
+                )
+                for hyperlink in work_item.hyperlinks
+            ]
+
+        attrs.additional_properties.update(work_item.additional_attributes)
+        assert work_item.id is not None
+
+        return api_models.WorkitemsListPatchRequestDataItem(
+            type_=api_models.WorkitemsListPatchRequestDataItemType.WORKITEMS,
+            id=f"{self._project_id}/{work_item.id}",
+            attributes=attrs,
+        )
+
+    def _calculate_patch_work_item_request_sizes(
+        self,
+        work_item_data: api_models.WorkitemsListPatchRequestDataItem,
+        current_content_size: int = min_wi_patch_request_size,
+    ) -> tuple[int, bool]:
+        work_item_size = _get_json_content_size(work_item_data.to_dict())
+
+        proj_content_size = current_content_size + work_item_size
+        if current_content_size != min_wi_patch_request_size:
+            proj_content_size += len(b", ")
+
+        return (
+            proj_content_size,
+            (work_item_size + min_wi_patch_request_size)
+            > self._client.max_content_size,
+        )
+
+    def _patch_work_item_batch(
+        self,
+        work_item_batch: api_models.WorkitemsListPatchRequest,
+        batch_type: str | None,
+    ) -> None:
+        response = patch_work_items.sync_detailed(
+            self._project_id,
+            client=self._client.client,
+            change_type_to=batch_type or oa_types.UNSET,
+            body=work_item_batch,
+        )
+        self._raise_on_error(response)
+
+    async def _a_patch_work_item_batch(
+        self,
+        work_item_batch: api_models.WorkitemsListPatchRequest,
+        batch_type: str | None,
+    ) -> None:
+        response = await patch_work_items.asyncio_detailed(
+            self._project_id,
+            client=self._client.client,
+            change_type_to=batch_type or oa_types.UNSET,
+            body=work_item_batch,
+        )
+        self._raise_on_error(response)
 
     def _post_work_item_batch(
         self,

--- a/polarion_rest_api_client/clients/work_items.py
+++ b/polarion_rest_api_client/clients/work_items.py
@@ -22,7 +22,6 @@ from . import base_classes as bc
 from . import test_steps, work_item_attachments, work_item_links
 
 WT = t.TypeVar("WT", bound=dm.WorkItem)
-BT = t.TypeVar("BT")
 logger = logging.getLogger(__name__)
 if t.TYPE_CHECKING:
     from polarion_rest_api_client import client as polarion_client
@@ -73,33 +72,6 @@ class WorkItems(
     def _update(self, to_update: list[dm.WorkItem]) -> None:
         raise NotImplementedError("We have a custom update instead.")
 
-    def _flush_or_append_batch_item(
-        self,
-        current_batch_data: list[BT],
-        item_data: BT,
-        *,
-        projected_content_size: int,
-        new_batch_content_size: int,
-    ) -> tuple[bool, int]:
-        if (
-            current_batch_data
-            and projected_content_size > self._client.max_content_size
-        ) or len(current_batch_data) >= self._client.batch_size:
-            return True, new_batch_content_size
-
-        current_batch_data.append(item_data)
-        return False, projected_content_size
-
-    def _iter_update_groups(
-        self,
-        items: list[dm.WorkItem],
-    ) -> t.Iterable[tuple[str | None, list[dm.WorkItem]]]:
-        grouped: dict[str | None, list[dm.WorkItem]] = {}
-        for item in items:
-            grouped.setdefault(item.type, []).append(item)
-
-        yield from grouped.items()
-
     def _iter_update_batches(
         self,
         items: list[dm.WorkItem],
@@ -108,7 +80,11 @@ class WorkItems(
         None,
         None,
     ]:
-        for batch_type, to_update in self._iter_update_groups(items):
+        grouped: dict[str | None, list[dm.WorkItem]] = {}
+        for item in items:
+            grouped.setdefault(item.type, []).append(item)
+
+        for batch_type, to_update in grouped.items():
             current_batch = api_models.WorkitemsListPatchRequest(data=[])
             content_size = min_wi_patch_request_size
 
@@ -127,21 +103,24 @@ class WorkItems(
                         "A WorkItem is too large to update.", work_item
                     )
 
-                new_batch = api_models.WorkitemsListPatchRequest(
-                    data=[work_item_data]
-                )
                 assert isinstance(current_batch.data, list)
-                should_flush, content_size = self._flush_or_append_batch_item(
-                    current_batch.data,
-                    work_item_data,
-                    projected_content_size=proj_content_size,
-                    new_batch_content_size=_get_json_content_size(
-                        new_batch.to_dict()
-                    ),
-                )
-                if should_flush:
+                if (
+                    current_batch.data
+                    and proj_content_size > self._client.max_content_size
+                ) or len(current_batch.data) >= self._client.batch_size:
                     yield current_batch, batch_type
-                    current_batch = new_batch
+                    current_batch = api_models.WorkitemsListPatchRequest(
+                        data=[work_item_data]
+                    )
+                    content_size = _get_json_content_size(
+                        current_batch.to_dict()
+                    )
+                else:
+                    t.cast(
+                        list[api_models.WorkitemsListPatchRequestDataItem],
+                        current_batch.data,
+                    ).append(work_item_data)
+                    content_size = proj_content_size
 
             if current_batch.data:
                 yield current_batch, batch_type
@@ -172,22 +151,23 @@ class WorkItems(
                     "A WorkItem is too large to create.", work_item
                 )
 
-            new_batch = api_models.WorkitemsListPostRequest(
-                data=[work_item_data]
-            )
             assert isinstance(current_batch.data, list)
-            should_flush, content_size = self._flush_or_append_batch_item(
-                current_batch.data,
-                work_item_data,
-                projected_content_size=proj_content_size,
-                new_batch_content_size=_get_json_content_size(
-                    new_batch.to_dict()
-                ),
-            )
-            if should_flush:
+            if (
+                current_batch.data
+                and proj_content_size > self._client.max_content_size
+            ) or len(current_batch.data) >= self._client.batch_size:
                 yield current_batch, items[batch_start_index:batch_end_index]
-                current_batch = new_batch
+                current_batch = api_models.WorkitemsListPostRequest(
+                    data=[work_item_data]
+                )
+                content_size = _get_json_content_size(current_batch.to_dict())
                 batch_start_index = batch_end_index
+            else:
+                t.cast(
+                    list[api_models.WorkitemsListPostRequestDataItem],
+                    current_batch.data,
+                ).append(work_item_data)
+                content_size = proj_content_size
 
         if current_batch.data:
             yield current_batch, items[batch_start_index:]

--- a/polarion_rest_api_client/clients/work_items.py
+++ b/polarion_rest_api_client/clients/work_items.py
@@ -72,58 +72,77 @@ class WorkItems(
     def _update(self, to_update: list[dm.WorkItem]) -> None:
         raise NotImplementedError("We have a custom update instead.")
 
+    def _iter_patch_batches(
+        self,
+        items: t.Iterable[dm.WorkItem],
+        item_builder: t.Callable[
+            [dm.WorkItem], api_models.WorkitemsListPatchRequestDataItem
+        ],
+    ) -> t.Generator[api_models.WorkitemsListPatchRequest, None, None]:
+        current_batch = api_models.WorkitemsListPatchRequest(data=[])
+        content_size = min_wi_patch_request_size
+
+        for work_item in items:
+            work_item_data = item_builder(work_item)
+            proj_content_size, too_big = (
+                self._calculate_patch_work_item_request_sizes(
+                    work_item_data, content_size
+                )
+            )
+
+            if too_big:
+                raise errors.PolarionWorkItemException(
+                    "A WorkItem is too large to update.", work_item
+                )
+
+            assert isinstance(current_batch.data, list)
+            if (
+                current_batch.data
+                and proj_content_size > self._client.max_content_size
+            ) or len(current_batch.data) >= self._client.batch_size:
+                yield current_batch
+                current_batch = api_models.WorkitemsListPatchRequest(
+                    data=[work_item_data]
+                )
+                content_size = _get_json_content_size(current_batch.to_dict())
+            else:
+                t.cast(
+                    list[api_models.WorkitemsListPatchRequestDataItem],
+                    current_batch.data,
+                ).append(work_item_data)
+                content_size = proj_content_size
+
+        if current_batch.data:
+            yield current_batch
+
     def _iter_update_batches(
         self,
         items: list[dm.WorkItem],
+    ) -> t.Generator[api_models.WorkitemsListPatchRequest, None, None]:
+        yield from self._iter_patch_batches(
+            (item for item in items if self._has_content_to_patch(item)),
+            self._build_work_item_list_patch_item,
+        )
+
+    def _iter_type_change_batches(
+        self,
+        items: list[dm.WorkItem],
     ) -> t.Generator[
-        tuple[api_models.WorkitemsListPatchRequest, str | None],
+        tuple[api_models.WorkitemsListPatchRequest, str],
         None,
         None,
     ]:
-        grouped: dict[str | None, list[dm.WorkItem]] = {}
+        grouped: dict[str, list[dm.WorkItem]] = {}
         for item in items:
-            grouped.setdefault(item.type, []).append(item)
+            if item.type:
+                grouped.setdefault(item.type, []).append(item)
 
         for batch_type, to_update in grouped.items():
-            current_batch = api_models.WorkitemsListPatchRequest(data=[])
-            content_size = min_wi_patch_request_size
-
-            for work_item in to_update:
-                work_item_data = self._build_work_item_list_patch_item(
-                    work_item
-                )
-                proj_content_size, too_big = (
-                    self._calculate_patch_work_item_request_sizes(
-                        work_item_data, content_size
-                    )
-                )
-
-                if too_big:
-                    raise errors.PolarionWorkItemException(
-                        "A WorkItem is too large to update.", work_item
-                    )
-
-                assert isinstance(current_batch.data, list)
-                if (
-                    current_batch.data
-                    and proj_content_size > self._client.max_content_size
-                ) or len(current_batch.data) >= self._client.batch_size:
-                    yield current_batch, batch_type
-                    current_batch = api_models.WorkitemsListPatchRequest(
-                        data=[work_item_data]
-                    )
-                    content_size = _get_json_content_size(
-                        current_batch.to_dict()
-                    )
-                else:
-                    t.cast(
-                        list[api_models.WorkitemsListPatchRequestDataItem],
-                        current_batch.data,
-                    ).append(work_item_data)
-                    content_size = proj_content_size
-
-            if current_batch.data:
-                yield current_batch, batch_type
+            for batch in self._iter_patch_batches(
+                to_update,
+                self._build_work_item_type_change_patch_item,
+            ):
+                yield batch, batch_type
 
     def _iter_create_batches(
         self, items: list[dm.WorkItem]
@@ -180,8 +199,13 @@ class WorkItems(
         if not isinstance(items, list):
             items = [items]
 
-        for work_item_batch, batch_type in self._iter_update_batches(items):
-            self._patch_work_item_batch(work_item_batch, batch_type)
+        for work_item_batch, type_change_to in self._iter_type_change_batches(
+            items
+        ):
+            self._patch_work_item_batch(work_item_batch, type_change_to)
+
+        for work_item_batch in self._iter_update_batches(items):
+            self._patch_work_item_batch(work_item_batch, None)
 
     async def _async_update(self, to_update: list[dm.WorkItem]) -> None:
         raise NotImplementedError("We have a custom async_update instead.")
@@ -195,8 +219,18 @@ class WorkItems(
             items = [items]
 
         await self._run_streaming_batch_calls(
-            self._a_patch_work_item_batch(work_item_batch, batch_type)
-            for work_item_batch, batch_type in self._iter_update_batches(items)
+            self._a_patch_work_item_batch(work_item_batch, type_change_to)
+            for work_item_batch, type_change_to in self._iter_type_change_batches(
+                items
+            )
+        )
+
+        await self._run_streaming_batch_calls(
+            self._a_patch_work_item_batch(
+                work_item_batch,
+                None,
+            )
+            for work_item_batch in self._iter_update_batches(items)
         )
 
     @t.overload  # type: ignore[override]
@@ -652,13 +686,6 @@ class WorkItems(
     def _build_work_item_list_patch_item(
         self, work_item: dm.WorkItem
     ) -> api_models.WorkitemsListPatchRequestDataItem:
-        if work_item.type:
-            logger.warning(
-                "Attempting to change the type of Work Item %s to %s.",
-                work_item.id,
-                work_item.type,
-            )
-
         attrs = api_models.WorkitemsListPatchRequestDataItemAttributes()
 
         if work_item.home_document:
@@ -701,6 +728,39 @@ class WorkItems(
             type_=api_models.WorkitemsListPatchRequestDataItemType.WORKITEMS,
             id=f"{self._project_id}/{work_item.id}",
             attributes=attrs,
+        )
+
+    def _build_work_item_type_change_patch_item(
+        self, work_item: dm.WorkItem
+    ) -> api_models.WorkitemsListPatchRequestDataItem:
+        if work_item.id is None:
+            raise errors.PolarionWorkItemException(
+                "A WorkItem ID is required to update.",
+                work_item,
+            )
+
+        logger.warning(
+            "Attempting to change the type of Work Item %s to %s.",
+            work_item.id,
+            work_item.type,
+        )
+
+        return api_models.WorkitemsListPatchRequestDataItem(
+            type_=api_models.WorkitemsListPatchRequestDataItemType.WORKITEMS,
+            id=f"{self._project_id}/{work_item.id}",
+            attributes=oa_types.UNSET,
+        )
+
+    def _has_content_to_patch(self, work_item: dm.WorkItem) -> bool:
+        return any(
+            [
+                work_item.title is not None,
+                work_item.description is not None,
+                work_item.status is not None,
+                work_item.hyperlinks is not None,
+                bool(work_item.additional_attributes),
+                work_item.home_document is not None,
+            ]
         )
 
     def _calculate_patch_work_item_request_sizes(

--- a/polarion_rest_api_client/clients/work_items.py
+++ b/polarion_rest_api_client/clients/work_items.py
@@ -82,12 +82,9 @@ class WorkItems(
         new_batch_content_size: int,
     ) -> tuple[bool, int]:
         if (
-            (
-                current_batch_data
-                and projected_content_size > self._client.max_content_size
-            )
-            or len(current_batch_data) >= self._client.batch_size
-        ):
+            current_batch_data
+            and projected_content_size > self._client.max_content_size
+        ) or len(current_batch_data) >= self._client.batch_size:
             return True, new_batch_content_size
 
         current_batch_data.append(item_data)
@@ -175,7 +172,9 @@ class WorkItems(
                     "A WorkItem is too large to create.", work_item
                 )
 
-            new_batch = api_models.WorkitemsListPostRequest(data=[work_item_data])
+            new_batch = api_models.WorkitemsListPostRequest(
+                data=[work_item_data]
+            )
             assert isinstance(current_batch.data, list)
             should_flush, content_size = self._flush_or_append_batch_item(
                 current_batch.data,

--- a/polarion_rest_api_client/clients/work_items.py
+++ b/polarion_rest_api_client/clients/work_items.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 """Implementation of a client providing work item specific functions."""
 
-import asyncio
 import itertools
 import json
 import logging
@@ -50,7 +49,6 @@ class WorkItems(
 ):
     """A project specific client for work item operations."""
 
-    _update_batch_size = 100
     _retry_methods: t.ClassVar[set[str]] = {
         "_post_work_item_batch",
         "_a_post_work_item_batch",
@@ -190,13 +188,9 @@ class WorkItems(
         if not isinstance(items, list):
             items = [items]
 
-        await asyncio.gather(
-            *[
-                self._a_patch_work_item_batch(work_item_batch, batch_type)
-                for work_item_batch, batch_type in self._iter_update_batches(
-                    items
-                )
-            ]
+        await self._run_streaming_batch_calls(
+            self._a_patch_work_item_batch(work_item_batch, batch_type)
+            for work_item_batch, batch_type in self._iter_update_batches(items)
         )
 
     @t.overload  # type: ignore[override]
@@ -516,13 +510,11 @@ class WorkItems(
         if not isinstance(items, list):
             items = [items]
 
-        await asyncio.gather(
-            *[
-                self._a_post_work_item_batch(work_item_batch, work_item_objs)
-                for work_item_batch, work_item_objs in self._iter_create_batches(
-                    items
-                )
-            ]
+        await self._run_streaming_batch_calls(
+            self._a_post_work_item_batch(work_item_batch, work_item_objs)
+            for work_item_batch, work_item_objs in self._iter_create_batches(
+                items
+            )
         )
 
     def _delete(self, items: list[dm.WorkItem]) -> None:

--- a/polarion_rest_api_client/clients/work_items.py
+++ b/polarion_rest_api_client/clients/work_items.py
@@ -742,7 +742,7 @@ class WorkItems(
         return api_models.WorkitemsListPatchRequestDataItem(
             type_=api_models.WorkitemsListPatchRequestDataItemType.WORKITEMS,
             id=f"{self._project_id}/{work_item.id}",
-            attributes=oa_types.UNSET,
+            attributes=api_models.WorkitemsListPatchRequestDataItemAttributes(),
         )
 
     def _has_content_to_patch(self, work_item: dm.WorkItem) -> bool:

--- a/polarion_rest_api_client/clients/work_items.py
+++ b/polarion_rest_api_client/clients/work_items.py
@@ -75,11 +75,13 @@ class WorkItems(
     def _update(self, to_update: list[dm.WorkItem]) -> None:
         raise NotImplementedError("We have a custom update instead.")
 
-    def update(self, items: dm.WorkItem | list[dm.WorkItem]) -> None:
-        """Update WorkItems and respect max body size and batch limits."""
-        if not isinstance(items, list):
-            items = [items]
-
+    def _iter_update_batches(
+        self, items: list[dm.WorkItem]
+    ) -> t.Generator[
+        tuple[api_models.WorkitemsListPatchRequest, str | None],
+        None,
+        None,
+    ]:
         for batch_type, to_update in itertools.groupby(
             items, lambda item: item.type
         ):
@@ -87,7 +89,6 @@ class WorkItems(
             content_size = min_wi_patch_request_size
 
             for work_item in to_update:
-                assert work_item.id is not None
                 work_item_data = self._build_work_item_list_patch_item(
                     work_item
                 )
@@ -107,8 +108,7 @@ class WorkItems(
                     proj_content_size >= self._client.max_content_size
                     or len(current_batch.data) >= self._client.batch_size
                 ):
-                    self._patch_work_item_batch(current_batch, batch_type)
-
+                    yield current_batch, batch_type
                     current_batch = api_models.WorkitemsListPatchRequest(
                         data=[work_item_data]
                     )
@@ -123,10 +123,65 @@ class WorkItems(
                     content_size = proj_content_size
 
             if current_batch.data:
-                self._patch_work_item_batch(current_batch, batch_type)
+                yield current_batch, batch_type
+
+    def _iter_create_batches(
+        self, items: list[dm.WorkItem]
+    ) -> t.Generator[
+        tuple[api_models.WorkitemsListPostRequest, list[dm.WorkItem]],
+        None,
+        None,
+    ]:
+        current_batch = api_models.WorkitemsListPostRequest(data=[])
+        content_size = min_wi_request_size
+        batch_start_index = 0
+
+        for batch_end_index, work_item in enumerate(items):
+            work_item_data = self._build_work_item_post_request(work_item)
+
+            (
+                proj_content_size,
+                too_big,
+            ) = self._calculate_post_work_item_request_sizes(
+                work_item_data, content_size
+            )
+
+            if too_big:
+                raise errors.PolarionWorkItemException(
+                    "A WorkItem is too large to create.", work_item
+                )
+
+            assert isinstance(current_batch.data, list)
+            if (
+                proj_content_size >= self._client.max_content_size
+                or len(current_batch.data) >= self._client.batch_size
+            ):
+                yield current_batch, items[batch_start_index:batch_end_index]
+                current_batch = api_models.WorkitemsListPostRequest(
+                    data=[work_item_data]
+                )
+                content_size = _get_json_content_size(current_batch.to_dict())
+                batch_start_index = batch_end_index
+            else:
+                t.cast(
+                    list[api_models.WorkitemsListPostRequestDataItem],
+                    current_batch.data,
+                ).append(work_item_data)
+                content_size = proj_content_size
+
+        if current_batch.data:
+            yield current_batch, items[batch_start_index:]
+
+    def update(self, items: dm.WorkItem | list[dm.WorkItem]) -> None:
+        """Update WorkItems and respect max body size and batch limits."""
+        if not isinstance(items, list):
+            items = [items]
+
+        for work_item_batch, batch_type in self._iter_update_batches(items):
+            self._patch_work_item_batch(work_item_batch, batch_type)
 
     async def _async_update(self, to_update: list[dm.WorkItem]) -> None:
-        raise NotImplementedError("We have a custom update instead.")
+        raise NotImplementedError("We have a custom async_update instead.")
 
     async def async_update(
         self, items: dm.WorkItem | list[dm.WorkItem]
@@ -135,76 +190,14 @@ class WorkItems(
         if not isinstance(items, list):
             items = [items]
 
-        patch_batches: list[
-            tuple[api_models.WorkitemsListPatchRequest, str | None]
-        ] = []
-
-        for batch_type, to_update in itertools.groupby(
-            items, lambda item: item.type
-        ):
-            current_batch = api_models.WorkitemsListPatchRequest(data=[])
-            content_size = min_wi_patch_request_size
-
-            for work_item in to_update:
-                work_item_data = self._build_work_item_list_patch_item(
-                    work_item
-                )
-                proj_content_size, too_big = (
-                    self._calculate_patch_work_item_request_sizes(
-                        work_item_data, content_size
-                    )
-                )
-
-                if too_big:
-                    raise errors.PolarionWorkItemException(
-                        "A WorkItem is too large to update.", work_item
-                    )
-
-                assert isinstance(current_batch.data, list)
-                if (
-                    proj_content_size >= self._client.max_content_size
-                    or len(current_batch.data) >= self._client.batch_size
-                ):
-                    patch_batches.append((current_batch, batch_type))
-
-                    current_batch = api_models.WorkitemsListPatchRequest(
-                        data=[work_item_data]
-                    )
-                    content_size = _get_json_content_size(
-                        current_batch.to_dict()
-                    )
-                else:
-                    t.cast(
-                        list[api_models.WorkitemsListPatchRequestDataItem],
-                        current_batch.data,
-                    ).append(work_item_data)
-                    content_size = proj_content_size
-
-            if current_batch.data:
-                patch_batches.append((current_batch, batch_type))
-
         await asyncio.gather(
             *[
                 self._a_patch_work_item_batch(work_item_batch, batch_type)
-                for work_item_batch, batch_type in patch_batches
+                for work_item_batch, batch_type in self._iter_update_batches(
+                    items
+                )
             ]
         )
-
-    def _check_update_items(self, to_update: list[dm.WorkItem]) -> str | None:
-        assert to_update, "Expected at least one item"
-
-        batch_type = to_update[0].type
-        for item in to_update:
-            assert item.id is not None
-            assert item.type == batch_type
-            if item.type:
-                logger.warning(
-                    "Attempting to change the type of Work Item %s to %s.",
-                    item.id,
-                    item.type,
-                )
-
-        return batch_type
 
     @t.overload  # type: ignore[override]
     def get_multi(
@@ -507,53 +500,14 @@ class WorkItems(
         """Create WorkItems and respect the max body size of the server."""
         if not isinstance(items, list):
             items = [items]
-        current_batch = api_models.WorkitemsListPostRequest(data=[])
-        content_size = min_wi_request_size
-        batch_start_index = 0
 
-        for batch_end_index, work_item in enumerate(items):
-            work_item_data = self._build_work_item_post_request(work_item)
-
-            (
-                proj_content_size,
-                too_big,
-            ) = self._calculate_post_work_item_request_sizes(
-                work_item_data, content_size
-            )
-
-            if too_big:
-                raise errors.PolarionWorkItemException(
-                    "A WorkItem is too large to create.", work_item
-                )
-
-            assert isinstance(current_batch.data, list)
-            if (
-                proj_content_size >= self._client.max_content_size
-                or len(current_batch.data) >= self._client.batch_size
-            ):
-                self._post_work_item_batch(
-                    current_batch,
-                    items[batch_start_index:batch_end_index],
-                )
-
-                current_batch = api_models.WorkitemsListPostRequest(
-                    data=[work_item_data]
-                )
-                content_size = _get_json_content_size(current_batch.to_dict())
-                batch_start_index = batch_end_index
-            else:
-                assert isinstance(current_batch.data, list)
-                current_batch.data.append(work_item_data)
-                content_size = proj_content_size
-
-        if current_batch.data:
-            self._post_work_item_batch(
-                current_batch,
-                items[batch_start_index:],
-            )
+        for work_item_batch, work_item_objs in self._iter_create_batches(
+            items
+        ):
+            self._post_work_item_batch(work_item_batch, work_item_objs)
 
     async def _async_create(self, items: list[dm.WorkItem]) -> None:
-        raise NotImplementedError("We have a custom create instead.")
+        raise NotImplementedError("We have a custom async_create instead.")
 
     async def async_create(
         self, items: dm.WorkItem | list[dm.WorkItem]
@@ -561,57 +515,13 @@ class WorkItems(
         """Create WorkItems and respect the max body size of the server."""
         if not isinstance(items, list):
             items = [items]
-        post_batches: list[
-            tuple[api_models.WorkitemsListPostRequest, list[dm.WorkItem]]
-        ] = []
-        current_batch = api_models.WorkitemsListPostRequest(data=[])
-        content_size = min_wi_request_size
-        batch_start_index = 0
-
-        for batch_end_index, work_item in enumerate(items):
-            work_item_data = self._build_work_item_post_request(work_item)
-
-            (
-                proj_content_size,
-                too_big,
-            ) = self._calculate_post_work_item_request_sizes(
-                work_item_data, content_size
-            )
-
-            if too_big:
-                raise errors.PolarionWorkItemException(
-                    "A WorkItem is too large to create.", work_item
-                )
-
-            assert isinstance(current_batch.data, list)
-            if (
-                proj_content_size >= self._client.max_content_size
-                or len(current_batch.data) >= self._client.batch_size
-            ):
-                post_batches.append(
-                    (
-                        current_batch,
-                        items[batch_start_index:batch_end_index],
-                    )
-                )
-
-                current_batch = api_models.WorkitemsListPostRequest(
-                    data=[work_item_data]
-                )
-                content_size = _get_json_content_size(current_batch.to_dict())
-                batch_start_index = batch_end_index
-            else:
-                assert isinstance(current_batch.data, list)
-                current_batch.data.append(work_item_data)
-                content_size = proj_content_size
-
-        if current_batch.data:
-            post_batches.append((current_batch, items[batch_start_index:]))
 
         await asyncio.gather(
             *[
                 self._a_post_work_item_batch(work_item_batch, work_item_objs)
-                for work_item_batch, work_item_objs in post_batches
+                for work_item_batch, work_item_objs in self._iter_create_batches(
+                    items
+                )
             ]
         )
 
@@ -783,7 +693,11 @@ class WorkItems(
             ]
 
         attrs.additional_properties.update(work_item.additional_attributes)
-        assert work_item.id is not None
+        if work_item.id is None:
+            raise errors.PolarionWorkItemException(
+                "A WorkItem ID is required to update.",
+                work_item,
+            )
 
         return api_models.WorkitemsListPatchRequestDataItem(
             type_=api_models.WorkitemsListPatchRequestDataItemType.WORKITEMS,

--- a/tests/data/expected_requests/patch_work_item_completely.json
+++ b/tests/data/expected_requests/patch_work_item_completely.json
@@ -1,16 +1,18 @@
 {
-  "data": {
-    "type": "workitems",
-    "id": "PROJ/MyWorkItemId",
-    "attributes": {
-      "description": {
-        "type": "text/html",
-        "value": "My text value"
-      },
-      "title": "Title",
-      "status": "open",
-      "capella_uuid": "qwertz",
-      "cfOwner": "NewOwner"
+  "data": [
+    {
+      "type": "workitems",
+      "id": "PROJ/MyWorkItemId",
+      "attributes": {
+        "description": {
+          "type": "text/html",
+          "value": "My text value"
+        },
+        "title": "Title",
+        "status": "open",
+        "capella_uuid": "qwertz",
+        "cfOwner": "NewOwner"
+      }
     }
-  }
+  ]
 }

--- a/tests/data/expected_requests/patch_work_item_description.json
+++ b/tests/data/expected_requests/patch_work_item_description.json
@@ -1,12 +1,14 @@
 {
-  "data": {
-    "type": "workitems",
-    "id": "PROJ/MyWorkItemId",
-    "attributes": {
-      "description": {
-        "type": "text/html",
-        "value": "My text value"
+  "data": [
+    {
+      "type": "workitems",
+      "id": "PROJ/MyWorkItemId",
+      "attributes": {
+        "description": {
+          "type": "text/html",
+          "value": "My text value"
+        }
       }
     }
-  }
+  ]
 }

--- a/tests/data/expected_requests/patch_work_item_hyperlinks.json
+++ b/tests/data/expected_requests/patch_work_item_hyperlinks.json
@@ -1,19 +1,21 @@
 {
-  "data": {
-    "type": "workitems",
-    "id": "PROJ/MyWorkItemId",
-    "attributes": {
-      "hyperlinks": [
-        {
-          "role": "ref_ext",
-          "uri": "https://polarion.plm.automation.siemens.com"
-        },
-        {
-          "title": "Title",
-          "role": "ref_ext",
-          "uri": "https://polarion.plm.automation.siemens.com"
-        }
-      ]
+  "data": [
+    {
+      "type": "workitems",
+      "id": "PROJ/MyWorkItemId",
+      "attributes": {
+        "hyperlinks": [
+          {
+            "role": "ref_ext",
+            "uri": "https://polarion.plm.automation.siemens.com"
+          },
+          {
+            "title": "Title",
+            "role": "ref_ext",
+            "uri": "https://polarion.plm.automation.siemens.com"
+          }
+        ]
+      }
     }
-  }
+  ]
 }

--- a/tests/data/expected_requests/patch_work_item_status.json
+++ b/tests/data/expected_requests/patch_work_item_status.json
@@ -1,9 +1,11 @@
 {
-  "data": {
-    "type": "workitems",
-    "id": "PROJ/MyWorkItemId",
-    "attributes": {
-      "status": "open"
+  "data": [
+    {
+      "type": "workitems",
+      "id": "PROJ/MyWorkItemId",
+      "attributes": {
+        "status": "open"
+      }
     }
-  }
+  ]
 }

--- a/tests/data/expected_requests/patch_work_item_status_deleted.json
+++ b/tests/data/expected_requests/patch_work_item_status_deleted.json
@@ -1,9 +1,11 @@
 {
-  "data": {
-    "type": "workitems",
-    "id": "PROJ/MyWorkItemId",
-    "attributes": {
-      "status": "deleted"
+  "data": [
+    {
+      "type": "workitems",
+      "id": "PROJ/MyWorkItemId",
+      "attributes": {
+        "status": "deleted"
+      }
     }
-  }
+  ]
 }

--- a/tests/data/expected_requests/patch_work_item_title.json
+++ b/tests/data/expected_requests/patch_work_item_title.json
@@ -1,9 +1,11 @@
 {
-  "data": {
-    "type": "workitems",
-    "id": "PROJ/MyWorkItemId",
-    "attributes": {
-      "title": "Title"
+  "data": [
+    {
+      "type": "workitems",
+      "id": "PROJ/MyWorkItemId",
+      "attributes": {
+        "title": "Title"
+      }
     }
-  }
+  ]
 }

--- a/tests/test_client_workitems.py
+++ b/tests/test_client_workitems.py
@@ -619,7 +619,7 @@ def test_update_work_item_pure_type_change_single_request(
     assert req.url.params["changeTypeTo"] == "newType"
     req_data = json.loads(req.content.decode("utf-8"))
     assert len(req_data["data"]) == 1
-    assert "attributes" not in req_data["data"][0]
+    assert req_data["data"][0].get("attributes") == {}
 
 
 def test_update_work_items_split_by_type(

--- a/tests/test_client_workitems.py
+++ b/tests/test_client_workitems.py
@@ -631,7 +631,6 @@ def test_update_work_items_grouped_by_type_by_default(
 ):
     httpx_mock.add_response(204)
     httpx_mock.add_response(204)
-    httpx_mock.add_response(204)
 
     client.work_items.update(
         [
@@ -650,35 +649,6 @@ def test_update_work_items_grouped_by_type_by_default(
         "requirement",
     ]
     assert [len(json.loads(req.content.decode("utf-8"))["data"]) for req in reqs] == [2, 1]
-
-
-@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
-def test_update_work_items_can_disable_type_grouping(
-    client: polarion_api.ProjectClient,
-    httpx_mock: pytest_httpx.HTTPXMock,
-):
-    httpx_mock.add_response(204)
-    httpx_mock.add_response(204)
-    httpx_mock.add_response(204)
-
-    client.work_items.update(
-        [
-            polarion_api.WorkItem(id="WI-1", type="task", status="open"),
-            polarion_api.WorkItem(
-                id="WI-2", type="requirement", status="open"
-            ),
-            polarion_api.WorkItem(id="WI-3", type="task", status="open"),
-        ],
-        group_by_type=False,
-    )
-
-    reqs = httpx_mock.get_requests()
-    assert len(reqs) == 3
-    assert [req.url.params["changeTypeTo"] for req in reqs] == [
-        "task",
-        "requirement",
-        "task",
-    ]
 
 
 def test_iter_update_batches_does_not_emit_empty_batch_at_exact_size_boundary(

--- a/tests/test_client_workitems.py
+++ b/tests/test_client_workitems.py
@@ -465,7 +465,7 @@ def test_update_work_item_completely(
     req = httpx_mock.get_request()
 
     assert req is not None
-    assert req.url.path.endswith("PROJ/workitems/MyWorkItemId")
+    assert req.url.path.endswith("PROJ/workitems")
     assert req.method == "PATCH"
     with open(TEST_WI_PATCH_COMPLETELY_REQUEST, encoding="utf8") as f:
         assert json.loads(req.content.decode()) == json.load(f)
@@ -486,7 +486,7 @@ def test_update_work_item_description(
 
     req = httpx_mock.get_request()
     assert req is not None
-    assert req.url.path.endswith("PROJ/workitems/MyWorkItemId")
+    assert req.url.path.endswith("PROJ/workitems")
     assert req.method == "PATCH"
     with open(TEST_WI_PATCH_DESCRIPTION_REQUEST, encoding="utf8") as f:
         assert json.loads(req.content.decode()) == json.load(f)
@@ -519,7 +519,7 @@ def test_update_work_item_hyperlinks(
 
     req = httpx_mock.get_request()
     assert req is not None
-    assert req.url.path.endswith("PROJ/workitems/MyWorkItemId")
+    assert req.url.path.endswith("PROJ/workitems")
     assert req.method == "PATCH"
     assert json.loads(req.content.decode()) == expected_request
 
@@ -536,7 +536,7 @@ def test_update_work_item_title(
 
     req = httpx_mock.get_request()
     assert req is not None
-    assert req.url.path.endswith("PROJ/workitems/MyWorkItemId")
+    assert req.url.path.endswith("PROJ/workitems")
     assert req.method == "PATCH"
     with open(TEST_WI_PATCH_TITLE_REQUEST, encoding="utf8") as f:
         assert json.loads(req.content.decode()) == json.load(f)
@@ -555,7 +555,7 @@ def test_update_work_item_status(
     req = httpx_mock.get_request()
 
     assert req is not None
-    assert req.url.path.endswith("PROJ/workitems/MyWorkItemId")
+    assert req.url.path.endswith("PROJ/workitems")
     assert req.method == "PATCH"
     assert len(req.url.params) == 0
     with open(TEST_WI_PATCH_STATUS_REQUEST, encoding="utf8") as f:
@@ -574,11 +574,74 @@ def test_update_work_item_type(
 
     req = httpx_mock.get_request()
     assert req is not None
-    assert req.url.path.endswith("PROJ/workitems/MyWorkItemId")
+    assert req.url.path.endswith("PROJ/workitems")
     assert req.url.params["changeTypeTo"] == "newType"
     assert req.method == "PATCH"
     with open(TEST_WI_PATCH_STATUS_REQUEST, encoding="utf8") as f:
         assert json.loads(req.content.decode()) == json.load(f)
+
+
+def test_update_work_items_split_by_type(
+    client: polarion_api.ProjectClient,
+    httpx_mock: pytest_httpx.HTTPXMock,
+):
+    httpx_mock.add_response(204)
+    httpx_mock.add_response(204)
+
+    client.work_items.update(
+        [
+            polarion_api.WorkItem(id="WI-1", type="task", status="open"),
+            polarion_api.WorkItem(id="WI-2", type="task", status="open"),
+            polarion_api.WorkItem(
+                id="WI-3", type="requirement", status="open"
+            ),
+        ]
+    )
+
+    reqs = httpx_mock.get_requests()
+    assert len(reqs) == 2
+    assert all(req.method == "PATCH" for req in reqs)
+    assert all(req.url.path.endswith("PROJ/workitems") for req in reqs)
+    assert reqs[0].url.params["changeTypeTo"] == "task"
+    assert reqs[1].url.params["changeTypeTo"] == "requirement"
+    assert len(json.loads(reqs[0].content.decode("utf-8"))["data"]) == 2
+    assert len(json.loads(reqs[1].content.decode("utf-8"))["data"]) == 1
+
+
+def test_update_work_items_split_by_content_size(
+    client: polarion_api.ProjectClient,
+    httpx_mock: pytest_httpx.HTTPXMock,
+):
+    httpx_mock.add_response(204)
+    httpx_mock.add_response(204)
+    httpx_mock.add_response(204)
+
+    work_items = [
+        polarion_api.WorkItem(
+            id="WI-1",
+            description=polarion_api.HtmlContent("AB" * 700 * 1024),
+        ),
+        polarion_api.WorkItem(
+            id="WI-2",
+            description=polarion_api.HtmlContent("AB" * 700 * 1024),
+        ),
+        polarion_api.WorkItem(
+            id="WI-3",
+            description=polarion_api.HtmlContent("AB" * 700 * 1024),
+        ),
+    ]
+
+    client.work_items.update(work_items)
+
+    reqs = httpx_mock.get_requests()
+    assert len(reqs) == 3
+    assert all(req.method == "PATCH" for req in reqs)
+    assert all(req.url.path.endswith("PROJ/workitems") for req in reqs)
+    assert all(
+        len(json.loads(req.content.decode("utf-8"))["data"]) == 1
+        for req in reqs
+    )
+    assert all(len(req.content) <= 2 * 1024**2 for req in reqs)
 
 
 def test_delete_work_item_status_mode(

--- a/tests/test_client_workitems.py
+++ b/tests/test_client_workitems.py
@@ -10,6 +10,7 @@ import pytest
 import pytest_httpx
 
 import polarion_rest_api_client as polarion_api
+from polarion_rest_api_client.clients import work_items as work_items_client
 from tests.conftest import (
     TEST_ERROR_RESPONSE,
     TEST_WI_CREATED_RESPONSE,
@@ -29,6 +30,22 @@ from tests.conftest import (
     TEST_WI_POST_REQUEST,
     TEST_WI_SINGLE_RESPONSE,
 )
+
+
+def _build_project_client(
+    *,
+    batch_size: int = 3,
+    max_content_size: int = 2 * 1024**2,
+) -> polarion_api.ProjectClient:
+    client = polarion_api.PolarionClient(
+        polarion_api_endpoint="http://127.0.0.1/api",
+        polarion_access_token="PAT123",
+        batch_size=batch_size,
+        max_content_size=max_content_size,
+    )
+    return client.generate_project_client(
+        project_id="PROJ", delete_status="deleted"
+    )
 
 
 def test_get_one_work_item(
@@ -606,6 +623,121 @@ def test_update_work_items_split_by_type(
     assert reqs[1].url.params["changeTypeTo"] == "requirement"
     assert len(json.loads(reqs[0].content.decode("utf-8"))["data"]) == 2
     assert len(json.loads(reqs[1].content.decode("utf-8"))["data"]) == 1
+
+
+def test_update_work_items_grouped_by_type_by_default(
+    client: polarion_api.ProjectClient,
+    httpx_mock: pytest_httpx.HTTPXMock,
+):
+    httpx_mock.add_response(204)
+    httpx_mock.add_response(204)
+    httpx_mock.add_response(204)
+
+    client.work_items.update(
+        [
+            polarion_api.WorkItem(id="WI-1", type="task", status="open"),
+            polarion_api.WorkItem(
+                id="WI-2", type="requirement", status="open"
+            ),
+            polarion_api.WorkItem(id="WI-3", type="task", status="open"),
+        ]
+    )
+
+    reqs = httpx_mock.get_requests()
+    assert len(reqs) == 2
+    assert [req.url.params["changeTypeTo"] for req in reqs] == [
+        "task",
+        "requirement",
+    ]
+    assert [len(json.loads(req.content.decode("utf-8"))["data"]) for req in reqs] == [2, 1]
+
+
+@pytest.mark.httpx_mock(assert_all_responses_were_requested=False)
+def test_update_work_items_can_disable_type_grouping(
+    client: polarion_api.ProjectClient,
+    httpx_mock: pytest_httpx.HTTPXMock,
+):
+    httpx_mock.add_response(204)
+    httpx_mock.add_response(204)
+    httpx_mock.add_response(204)
+
+    client.work_items.update(
+        [
+            polarion_api.WorkItem(id="WI-1", type="task", status="open"),
+            polarion_api.WorkItem(
+                id="WI-2", type="requirement", status="open"
+            ),
+            polarion_api.WorkItem(id="WI-3", type="task", status="open"),
+        ],
+        group_by_type=False,
+    )
+
+    reqs = httpx_mock.get_requests()
+    assert len(reqs) == 3
+    assert [req.url.params["changeTypeTo"] for req in reqs] == [
+        "task",
+        "requirement",
+        "task",
+    ]
+
+
+def test_iter_update_batches_does_not_emit_empty_batch_at_exact_size_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    project_client = _build_project_client()
+
+    def fake_calculate_sizes(
+        _work_item_data: object,
+        current_content_size: int = work_items_client.min_wi_patch_request_size,
+    ) -> tuple[int, bool]:
+        if current_content_size == work_items_client.min_wi_patch_request_size:
+            return project_client._client.max_content_size, False
+        return current_content_size + 1, False
+
+    monkeypatch.setattr(
+        project_client.work_items,
+        "_calculate_patch_work_item_request_sizes",
+        fake_calculate_sizes,
+    )
+
+    batches = list(
+        project_client.work_items._iter_update_batches(
+            [polarion_api.WorkItem(id="WI-1", status="open")]
+        )
+    )
+
+    assert len(batches) == 1
+    assert batches[0][1] is None
+    assert isinstance(batches[0][0].data, list)
+    assert len(batches[0][0].data) == 1
+
+
+def test_iter_create_batches_does_not_emit_empty_batch_at_exact_size_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    project_client = _build_project_client()
+
+    def fake_calculate_sizes(
+        _work_item_data: object,
+        current_content_size: int = work_items_client.min_wi_request_size,
+    ) -> tuple[int, bool]:
+        if current_content_size == work_items_client.min_wi_request_size:
+            return project_client._client.max_content_size, False
+        return current_content_size + 1, False
+
+    monkeypatch.setattr(
+        project_client.work_items,
+        "_calculate_post_work_item_request_sizes",
+        fake_calculate_sizes,
+    )
+
+    work_item = polarion_api.WorkItem(type="task", status="open")
+    batches = list(project_client.work_items._iter_create_batches([work_item]))
+
+    assert len(batches) == 1
+    assert isinstance(batches[0][0].data, list)
+    assert len(batches[0][0].data) == 1
+    assert batches[0][1] == [work_item]
 
 
 def test_update_work_items_split_by_content_size(

--- a/tests/test_client_workitems.py
+++ b/tests/test_client_workitems.py
@@ -648,7 +648,9 @@ def test_update_work_items_grouped_by_type_by_default(
         "task",
         "requirement",
     ]
-    assert [len(json.loads(req.content.decode("utf-8"))["data"]) for req in reqs] == [2, 1]
+    assert [
+        len(json.loads(req.content.decode("utf-8"))["data"]) for req in reqs
+    ] == [2, 1]
 
 
 def test_iter_update_batches_does_not_emit_empty_batch_at_exact_size_boundary(

--- a/tests/test_client_workitems.py
+++ b/tests/test_client_workitems.py
@@ -584,24 +584,49 @@ def test_update_work_item_type(
     httpx_mock: pytest_httpx.HTTPXMock,
 ):
     httpx_mock.add_response(204)
+    httpx_mock.add_response(204)
 
     client.work_items.update(
         polarion_api.WorkItem(id="MyWorkItemId", type="newType", status="open")
     )
 
-    req = httpx_mock.get_request()
-    assert req is not None
+    reqs = httpx_mock.get_requests()
+    assert len(reqs) == 2
+    assert reqs[0].url.path.endswith("PROJ/workitems")
+    assert reqs[0].url.params["changeTypeTo"] == "newType"
+    assert reqs[0].method == "PATCH"
+    assert reqs[1].url.path.endswith("PROJ/workitems")
+    assert len(reqs[1].url.params) == 0
+    assert reqs[1].method == "PATCH"
+    with open(TEST_WI_PATCH_STATUS_REQUEST, encoding="utf8") as f:
+        assert json.loads(reqs[1].content.decode()) == json.load(f)
+
+
+def test_update_work_item_pure_type_change_single_request(
+    client: polarion_api.ProjectClient,
+    httpx_mock: pytest_httpx.HTTPXMock,
+):
+    httpx_mock.add_response(204)
+
+    client.work_items.update(
+        polarion_api.WorkItem(id="MyWorkItemId", type="newType")
+    )
+
+    reqs = httpx_mock.get_requests()
+    assert len(reqs) == 1
+    req = reqs[0]
     assert req.url.path.endswith("PROJ/workitems")
     assert req.url.params["changeTypeTo"] == "newType"
-    assert req.method == "PATCH"
-    with open(TEST_WI_PATCH_STATUS_REQUEST, encoding="utf8") as f:
-        assert json.loads(req.content.decode()) == json.load(f)
+    req_data = json.loads(req.content.decode("utf-8"))
+    assert len(req_data["data"]) == 1
+    assert "attributes" not in req_data["data"][0]
 
 
 def test_update_work_items_split_by_type(
     client: polarion_api.ProjectClient,
     httpx_mock: pytest_httpx.HTTPXMock,
 ):
+    httpx_mock.add_response(204)
     httpx_mock.add_response(204)
     httpx_mock.add_response(204)
 
@@ -616,19 +641,22 @@ def test_update_work_items_split_by_type(
     )
 
     reqs = httpx_mock.get_requests()
-    assert len(reqs) == 2
+    assert len(reqs) == 3
     assert all(req.method == "PATCH" for req in reqs)
     assert all(req.url.path.endswith("PROJ/workitems") for req in reqs)
     assert reqs[0].url.params["changeTypeTo"] == "task"
     assert reqs[1].url.params["changeTypeTo"] == "requirement"
     assert len(json.loads(reqs[0].content.decode("utf-8"))["data"]) == 2
     assert len(json.loads(reqs[1].content.decode("utf-8"))["data"]) == 1
+    assert len(reqs[2].url.params) == 0
+    assert len(json.loads(reqs[2].content.decode("utf-8"))["data"]) == 3
 
 
 def test_update_work_items_grouped_by_type_by_default(
     client: polarion_api.ProjectClient,
     httpx_mock: pytest_httpx.HTTPXMock,
 ):
+    httpx_mock.add_response(204)
     httpx_mock.add_response(204)
     httpx_mock.add_response(204)
 
@@ -643,14 +671,17 @@ def test_update_work_items_grouped_by_type_by_default(
     )
 
     reqs = httpx_mock.get_requests()
-    assert len(reqs) == 2
-    assert [req.url.params["changeTypeTo"] for req in reqs] == [
+    assert len(reqs) == 3
+    assert [req.url.params["changeTypeTo"] for req in reqs[:2]] == [
         "task",
         "requirement",
     ]
     assert [
-        len(json.loads(req.content.decode("utf-8"))["data"]) for req in reqs
+        len(json.loads(req.content.decode("utf-8"))["data"])
+        for req in reqs[:2]
     ] == [2, 1]
+    assert len(reqs[2].url.params) == 0
+    assert len(json.loads(reqs[2].content.decode("utf-8"))["data"]) == 3
 
 
 def test_iter_update_batches_does_not_emit_empty_batch_at_exact_size_boundary(
@@ -679,9 +710,8 @@ def test_iter_update_batches_does_not_emit_empty_batch_at_exact_size_boundary(
     )
 
     assert len(batches) == 1
-    assert batches[0][1] is None
-    assert isinstance(batches[0][0].data, list)
-    assert len(batches[0][0].data) == 1
+    assert isinstance(batches[0].data, list)
+    assert len(batches[0].data) == 1
 
 
 def test_iter_create_batches_does_not_emit_empty_batch_at_exact_size_boundary(


### PR DESCRIPTION
## Main change

This PR changes `WorkItems` update behavior from single-item PATCH calls to **batched** `patch_work_items` requests with a **two-phase update flow** for type changes.

## What was implemented

- Replaced per-item `patch_work_item` updates with batched `patch_work_items` requests.
- Implemented a **two-phase update**:
  1. **Type-change phase** (when `work_item.type` is set): sends `changeTypeTo` requests first.
  2. **Content patch phase**: sends regular PATCH requests without `changeTypeTo`.
- Ensured the type-change request is a **pure type change** (no content attributes in payload).
  - This is to avoid errors if fields are used, which are available on the new type only
- Added explicit validation that a Work Item ID is required for update requests.
- Added tests to verify:
  - batched PATCH behavior,
  - two-phase type/content flow,
  - pure type change results in exactly one request.

## Batching behavior

- Type-change batches are grouped by target type (`changeTypeTo`).
- Content patch batches are grouped independently of type.
- Both paths respect:
  - `max_content_size`
  - `batch_size`

## Secondary refactoring

- Reduced duplication by extracting shared patch batching logic into:
  - `_iter_patch_batches(...)`
- Reused it in:
  - `_iter_type_change_batches(...)`
  - `_iter_update_batches(...)`
- Kept async execution streaming-based to avoid eager materialization of all async calls.
